### PR TITLE
consistent user lookup, catch and log exception without exiting

### DIFF
--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -444,7 +444,7 @@ class EventHandler():
                     user_map.plaid_user_id = event_data["id"]
                     db.session.add(user_map)
                 except AttributeError:
-                    log.exception(f"Failed to create new user {event_data["name"]} (ID: {event_data["id"]}).")
+                    log.exception(f"Failed to create new user {event_data['name']} (ID: {event_data['id']}).")
 
             if plaid_role not in user.roles:
                 user.roles.append(plaid_role)


### PR DESCRIPTION
Since the reported issue that this PR hopes to fix is an unhandled exception, the pod restarts immediately after any stacktraces are logged. Unfortunately, due to [this behavior with filebeat](https://github.com/elastic/beats/issues/17396), there aren't any stacktraces logged to get a better idea on how to reproduce the root issue.

I added an exception handler for the reported stacktrace (that I managed to get last Thursday by tailing pod logs during an event failure):

```asciitext
Traceback (most recent call last):
  File "/plaid/plaid/event_handler.py", line 553, in <module>
    handler.consume()
  File "/plaid/plaid/event_handler.py", line 138, in consume
    self.process_event(data)
  File "/plaid/plaid/event_handler.py", line 157, in process_event
    handle_event(event_type, data, **kwargs)
  File "/plaid/plaid/event_handler.py", line 533, in _handle_user_event
    add_user(data)
  File "/plaid/plaid/event_handler.py", line 435, in add_user
    user_map.user_id = user.id
AttributeError: 'bool' object has no attribute 'id'
```

[This](https://github.com/dpgaspar/Flask-AppBuilder/blob/79f083228c12009d78d9fabbe7e1912ed510d65c/flask_appbuilder/security/sqla/manager.py#L214-L217) is the code that would report the error missing from the logs that would indicate the root cause:

```python
        except Exception as e:
            log.error(c.LOGMSG_ERR_SEC_ADD_USER.format(str(e)))
            self.get_session.rollback()
            return False
```

Which is the following template:

```python
LOGMSG_ERR_SEC_ADD_USER = "Error adding new user to database. {0}"
```

If the problem arises again, it will be logged without restarting the pod, so filebeat can harvest the error for further investigation.