### PR TITLE
make cache settings configurable for redis, sentinel, and none

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ podTemplate(label: 'superset',
                 package_helm_chart --repo-url=https://$user:$pass@github.com/PlaidCloud/k8s.git --chart-name=$chart_name
                 
                 # Tell argo which image version to use.
-                argocd app set $argo_app -p superset.image="$image_name/production:$image_label"
+                argocd app set $argo_app -p spec.image="$image_name/production:$image_label"
                 argocd app set $argo_app-events -p superset_events.image="$image_name/events:$image_label"
               """
             }

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: superset
 description: Deploys superset along with the proprietary superset-events service.
-version: 1.1.0
+version: 1.2.0
 keywords:
   - superset
   - plaid

--- a/charts/superset/templates/configmap.yaml
+++ b/charts/superset/templates/configmap.yaml
@@ -57,31 +57,34 @@ data:
   
     # Uncomment to setup an App icon
     APP_ICON = '/static/assets/images/plaidcloud.png'
-  
+    {{- if .Values.redis.enabled }}
     CACHE_CONFIG: CacheConfig = {
-        'CACHE_TYPE': '{{ .Values.devMode | ternary "redis" "redissentinel" }}',
-        {{- if .Values.devMode }}
-        'CACHE_REDIS_HOST': '{{ .Values.redis.host }}',
-        'CACHE_REDIS_PORT': {{ .Values.redis.port }},
-        {{- else }}
+        {{- if .Values.redis.group }}
+        'CACHE_TYPE': 'redissentinel',
         'CACHE_REDIS_SENTINELS': [("{{ .Values.redis.host }}", {{ .Values.redis.port }})],
         'CACHE_REDIS_SENTINEL_MASTER': "{{ .Values.redis.group }}",
+        {{- else }}
+        'CACHE_TYPE': 'redis',
+        'CACHE_REDIS_HOST': '{{ .Values.redis.host }}',
+        'CACHE_REDIS_PORT': {{ .Values.redis.port }},
         {{- end }}
         'CACHE_REDIS_DB': {{ .Values.redis.cache_db }},
     }
     
     TABLE_NAMES_CACHE_CONFIG: CacheConfig = {
-        'CACHE_TYPE': '{{ .Values.devMode | ternary "redis" "redissentinel" }}',
-        {{- if .Values.devMode }}
-        'CACHE_REDIS_HOST': '{{ .Values.redis.host }}',
-        'CACHE_REDIS_PORT': {{ .Values.redis.port }},
-        {{- else }}
+        {{- if .Values.redis.group }}
+        'CACHE_TYPE': 'redissentinel',
         'CACHE_REDIS_SENTINELS': [("{{ .Values.redis.host }}", {{ .Values.redis.port }})],
         'CACHE_REDIS_SENTINEL_MASTER': "{{ .Values.redis.group }}",
+        {{- else }}
+        'CACHE_TYPE': 'redis',
+        'CACHE_REDIS_HOST': '{{ .Values.redis.host }}',
+        'CACHE_REDIS_PORT': {{ .Values.redis.port }},
         {{- end }}
         'CACHE_REDIS_DB': {{ .Values.redis.table_db }},
     }
-  
+    {{- end }}
+
     # Disable Druid. We don't use it.
     DRUID_IS_ACTIVE = False
   

--- a/charts/superset/templates/deployment.yaml
+++ b/charts/superset/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     plaid: superset
     release: {{ .Release.Name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.spec.replicas }}
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -17,9 +17,9 @@ spec:
   template:
     metadata:
       name: superset
-      {{- if .Values.superset.annotations }}
+      {{- if .Values.spec.annotations }}
       annotations:
-{{ toYaml .Values.superset.annotations | indent 8 }}
+{{ toYaml .Values.spec.annotations | indent 8 }}
       {{- end }}
       labels:
         app: plaid
@@ -28,20 +28,20 @@ spec:
     spec:
       containers:
       - name: superset
-        image: {{ .Values.superset.image }}
-        imagePullPolicy: {{ .Values.superset.pullPolicy }}
+        image: {{ .Values.spec.image }}
+        imagePullPolicy: {{ .Values.spec.pullPolicy }}
         {{- if .Values.devMode }}
         command: ["flask", "run", "-p", "8088", "--with-threads", "--reload", "--debugger", "--host=0.0.0.0"]
         {{- end }}
         env:
-{{ .Values.superset.env | toYaml | indent 10 }}
+{{ .Values.spec.env | toYaml | indent 10 }}
         ports:
         - name: http
           containerPort: 8088
         volumeMounts:
         - name: superset-conf
           mountPath: /etc/superset/
-        {{- if .Values.superset.dev }}      
+        {{- if .Values.devMode }}      
         - name: static-assets
           mountPath: /app/superset/static/assets
         {{- end }}
@@ -59,7 +59,7 @@ spec:
           mountPath: /app/superset/static/assets
       {{- end }}
       imagePullSecrets:
-      - name: {{ .Values.superset.imagePullSecret }}
+      - name: {{ .Values.spec.imagePullSecret }}
       volumes:
       - name: superset-conf
         configMap:

--- a/charts/superset/templates/ingress.yaml
+++ b/charts/superset/templates/ingress.yaml
@@ -29,5 +29,5 @@ spec:
       - path: /
         backend:
           serviceName: {{ .Release.Name }}
-          servicePort: {{ .Values.superset.port }}
+          servicePort: {{ .Values.spec.port }}
 {{- end }}

--- a/charts/superset/templates/service.yaml
+++ b/charts/superset/templates/service.yaml
@@ -8,11 +8,11 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   ports:
-  - port: {{ .Values.superset.port }}  
+  - port: {{ .Values.spec.port }}  
     {{- if .Values.devMode }}
     targetPort: {{ .Values.node.targetPort }}
     {{- else }}
-    targetPort: {{ .Values.superset.targetPort }}  
+    targetPort: {{ .Values.spec.targetPort }}  
     {{- end }}
     protocol: TCP
     name: http

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -1,6 +1,7 @@
 devMode: false
 
-superset:
+spec:
+  replicas: 1
   image: gcr.io/plaidcloud-build/superset/production:latest
   pullPolicy: Always
   imagePullSecret: gcr-key
@@ -62,8 +63,8 @@ oidc:
   redirectUris:
   - https://viz.plaidcloud.io/oidc_callback
   
-
 redis:
+  enabled: true
   host: "redis-master"
   port: 26379
   group: "superset"


### PR DESCRIPTION
Chart deploys superset with`'redissentinel'` cache as the default, with `'redis'` as the dev-only variety. This PR allows caching to be disabled entirely, as well as changing the cache type based on the presence of a `redis.group` value.