### PR TITLE
Changes misleading github action name

### DIFF
--- a/.github/workflows/build_io.yaml
+++ b/.github/workflows/build_io.yaml
@@ -1,4 +1,4 @@
-name: Deploy Superset to IO
+name: Build Superset for IO
 on:
   push:
     branches:


### PR DESCRIPTION
build_io.yaml just builds superset, it doesn't deploy it. You have to
deploy it manually.