### PR TITLE
Build ch10144

### DIFF
--- a/plaid/auth_oidc.py
+++ b/plaid/auth_oidc.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 class AuthOIDCView(AuthOIDView):
 
     @expose('/login/', methods=['GET', 'POST'])
-    def login(self, flag=True) -> Response:
+    def login(self, flag:bool=True) -> Response:
         oauth = self.appbuilder.sm.oauth
         redirect_uri = url_for('.authorize', _external=True, _scheme='https')
         return oauth.plaid.authorize_redirect(redirect_uri)

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -7,14 +7,19 @@ import uuid
 import time
 import jwt
 from typing import Union, List
+
 from sqlalchemy import func, Table, MetaData
 from urllib.parse import urljoin
-from superset.security import SupersetSecurityManager
 from flask import session
+from flask_login import logout_user
 from flask_appbuilder.security.manager import AUTH_OID
 from authlib.integrations.flask_client import OAuth
-from plaid.auth_oidc import AuthOIDCView
+from requests.exceptions import HTTPError
+
 from plaidcloud.rpc.connection.jsonrpc import SimpleRPC
+from plaid.auth_oidc import AuthOIDCView
+
+from superset.security import SupersetSecurityManager
 
 __author__ = "Garrett Bates"
 __copyright__ = "© Copyright 2018, Tartan Solutions, Inc"
@@ -110,7 +115,16 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
         temp_rpc = SimpleRPC(session['token']['access_token'], uri=rpc_url, verify_ssl=False)
 
-        authorized_workspaces = temp_rpc.identity.me.authorized_workspaces()
+        try:
+            authorized_workspaces = temp_rpc.identity.me.authorized_workspaces()
+        except HTTPError as e:
+            if e.response.status_code == 401:
+                #TODO: trigger a logout somehow
+                #      Not sure this will work without a redirect
+                logout_user()
+                session.clear()
+            raise
+
         try:
             session['workspace'] = next(
                 ws['id']

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -11,11 +11,9 @@ from typing import Union, List
 from sqlalchemy import func, Table, MetaData
 from urllib.parse import urljoin
 from flask import session
-import flask_login
 from flask_login import logout_user
 from flask_appbuilder.security.manager import AUTH_OID
 from authlib.integrations.flask_client import OAuth
-import requests
 from requests.exceptions import HTTPError
 
 from plaidcloud.rpc.connection.jsonrpc import SimpleRPC
@@ -119,19 +117,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
         try:
             authorized_workspaces = temp_rpc.identity.me.authorized_workspaces()
-            # Alright, I guess I need to figure out if a user is me, and if they are, raise an HTTPError. Hmm.
-            if flask_login.current_user.id == 47:
-                # Me, Adams
-                # TODO: if this just keeps looping, maybe do it at random, or after a 100 count or something
-                session['aw_count'] = session.get('aw_count', 0) + 1
-                log.info(f'aw_count incremented: {session["aw_count"]}')
-                if session['aw_count'] > 20:
-                    session['aw_count'] = 0  # This should be irrelevant, because session should be cleared
-                    log.info('Raising fake 401 error...')
-                    fake_response = requests.Response()
-                    fake_response.status_code = 401
-                    fake_response.reason = 'Fake 401 error for user 47'
-                    fake_response.raise_for_status()
         except HTTPError as e:
             if e.response.status_code == 401:
                 logout_user()

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -126,6 +126,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
                 session['aw_count'] = session.get('aw_count', 0) + 1
                 log.info(f'aw_count incremented: {aw_count}')
                 if session['aw_count'] > 20:
+                    session['aw_count'] = 0  # This should be irrelevant, because session should be cleared
                     log.info('Raising fake 401 error...')
                     fake_response = requests.Response()
                     fake_response.status_code = 401

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -11,9 +11,11 @@ from typing import Union, List
 from sqlalchemy import func, Table, MetaData
 from urllib.parse import urljoin
 from flask import session
+import flask_login
 from flask_login import logout_user
 from flask_appbuilder.security.manager import AUTH_OID
 from authlib.integrations.flask_client import OAuth
+import requests
 from requests.exceptions import HTTPError
 
 from plaidcloud.rpc.connection.jsonrpc import SimpleRPC
@@ -117,6 +119,14 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
         try:
             authorized_workspaces = temp_rpc.identity.me.authorized_workspaces()
+            # Alright, I guess I need to figure out if a user is me, and if they are, raise an HTTPError. Hmm.
+            if flask_login.current_user.id == 47:
+                # Me, Adams
+                # TODO: if this just keeps looping, maybe do it at random, or after a 100 count or something
+                fake_response = requests.Response():
+                fake_response.status_code = 401
+                fake_response.reason = 'Fake 401 error for user 47'
+                fake_response.raise_for_status()
         except HTTPError as e:
             if e.response.status_code == 401:
                 #TODO: trigger a logout somehow

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -137,7 +137,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
                 logout_user()
                 session.clear()
                 e.response.reason = '401 Unauthorized while running get_rpc(). Logging user out.'
-                return None
             raise
 
         try:
@@ -157,8 +156,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
     def can_access_database(self, database: Union["Database", "DruidCluster"]) -> bool:
         log.debug(f"Can access database: {database}")
         rpc = self.get_rpc()
-        if not rpc:
-            return False
         proj = rpc.analyze.project.project(project_id=str(database.uuid))
         log.debug(proj)
         if proj["id"] is None:
@@ -176,8 +173,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
             # Call the base method if there is no schema since it isn't a plaid table.
             return super().can_access_datasource(datasource)
         rpc = self.get_rpc()
-        if not rpc:
-            return False
         table_id = "{}{}".format("analyzetable_", str(datasource.uuid))
         table_id_without_dashes = table_id.replace("-", "")
         log.debug(f"Fetching table with name: {table_id}")
@@ -191,8 +186,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
     def get_project_ids(self):
         from superset.models.core import Database
         rpc = self.get_rpc()
-        if not rpc:
-            return []
         start = time.time()
         projects = rpc.analyze.project.projects()
         end = time.time()
@@ -219,8 +212,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def get_table_ids(self):
         rpc = self.get_rpc()
-        if not rpc:
-            return set()
         start = time.time()
         tables = rpc.analyze.table.published_tables_by_project()
         end = time.time()

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -134,11 +134,10 @@ class PlaidSecurityManager(SupersetSecurityManager):
                     fake_response.raise_for_status()
         except HTTPError as e:
             if e.response.status_code == 401:
-                log.info('Caught fake 401 error. Logging out user...')
-                #TODO: trigger a logout somehow
-                #      Not sure this will work without a redirect
                 logout_user()
                 session.clear()
+                e.response.reason = '401 Unauthorized while running get_rpc(). Logging user out.'
+                return None
             raise
 
         try:
@@ -158,6 +157,8 @@ class PlaidSecurityManager(SupersetSecurityManager):
     def can_access_database(self, database: Union["Database", "DruidCluster"]) -> bool:
         log.debug(f"Can access database: {database}")
         rpc = self.get_rpc()
+        if not rpc:
+            return False
         proj = rpc.analyze.project.project(project_id=str(database.uuid))
         log.debug(proj)
         if proj["id"] is None:
@@ -175,6 +176,8 @@ class PlaidSecurityManager(SupersetSecurityManager):
             # Call the base method if there is no schema since it isn't a plaid table.
             return super().can_access_datasource(datasource)
         rpc = self.get_rpc()
+        if not rpc:
+            return False
         table_id = "{}{}".format("analyzetable_", str(datasource.uuid))
         table_id_without_dashes = table_id.replace("-", "")
         log.debug(f"Fetching table with name: {table_id}")
@@ -188,6 +191,8 @@ class PlaidSecurityManager(SupersetSecurityManager):
     def get_project_ids(self):
         from superset.models.core import Database
         rpc = self.get_rpc()
+        if not rpc:
+            return []
         start = time.time()
         projects = rpc.analyze.project.projects()
         end = time.time()
@@ -214,6 +219,8 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def get_table_ids(self):
         rpc = self.get_rpc()
+        if not rpc:
+            return set()
         start = time.time()
         tables = rpc.analyze.table.published_tables_by_project()
         end = time.time()

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -124,7 +124,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
                 # Me, Adams
                 # TODO: if this just keeps looping, maybe do it at random, or after a 100 count or something
                 session['aw_count'] = session.get('aw_count', 0) + 1
-                log.info(f'aw_count incremented: {aw_count}')
+                log.info(f'aw_count incremented: {session["aw_count"]}')
                 if session['aw_count'] > 20:
                     session['aw_count'] = 0  # This should be irrelevant, because session should be cleared
                     log.info('Raising fake 401 error...')

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -121,7 +121,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
             if e.response.status_code == 401:
                 logout_user()
                 session.clear()
-                raise Exception('Unable to query plaid. Clearing user session. If you see this, please refresh.') from e
+                raise Exception('There were problems authenticating your access with PlaidCloud. If you see this message, please refresh your browser') from e
             raise
 
         try:

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -123,11 +123,14 @@ class PlaidSecurityManager(SupersetSecurityManager):
             if flask_login.current_user.id == 47:
                 # Me, Adams
                 # TODO: if this just keeps looping, maybe do it at random, or after a 100 count or something
-                log.info('Raising fake 401 error...')
-                fake_response = requests.Response()
-                fake_response.status_code = 401
-                fake_response.reason = 'Fake 401 error for user 47'
-                fake_response.raise_for_status()
+                session['aw_count'] = session.get('aw_count', 0) + 1
+                log.info(f'aw_count incremented: {aw_count}')
+                if session['aw_count'] > 20:
+                    log.info('Raising fake 401 error...')
+                    fake_response = requests.Response()
+                    fake_response.status_code = 401
+                    fake_response.reason = 'Fake 401 error for user 47'
+                    fake_response.raise_for_status()
         except HTTPError as e:
             if e.response.status_code == 401:
                 log.info('Caught fake 401 error. Logging out user...')

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -123,12 +123,14 @@ class PlaidSecurityManager(SupersetSecurityManager):
             if flask_login.current_user.id == 47:
                 # Me, Adams
                 # TODO: if this just keeps looping, maybe do it at random, or after a 100 count or something
-                fake_response = requests.Response():
+                log.info('Raising fake 401 error...')
+                fake_response = requests.Response()
                 fake_response.status_code = 401
                 fake_response.reason = 'Fake 401 error for user 47'
                 fake_response.raise_for_status()
         except HTTPError as e:
             if e.response.status_code == 401:
+                log.info('Caught fake 401 error. Logging out user...')
                 #TODO: trigger a logout somehow
                 #      Not sure this will work without a redirect
                 logout_user()

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -136,7 +136,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
             if e.response.status_code == 401:
                 logout_user()
                 session.clear()
-                e.response.reason = '401 Unauthorized while running get_rpc(). Logging user out.'
+                raise Exception('Unable to query plaid. Clearing user session. If you see this, please refresh.') from e
             raise
 
         try:


### PR DESCRIPTION
If the rpc methods are failing, logs out the user. Raises an error that should in most cases trigger a refresh/redirect to the superset homepage, but might in some cases be visible, in which case it instructs the user to refresh.