### PR TITLE
Build 10150

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 version: 0.6.1
 dependencies:
 - name: postgresql
-  version: 10.2.0
+  version: 10.16.2
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: redis

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.6.1
+version: 0.6.2
 dependencies:
 - name: postgresql
   version: 10.16.2

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -280,6 +280,8 @@ class EventHandler:
                 except SQLAlchemyError as ex:  # pragma: no cover
                     log.error(ex, exc_info=True)
                     db.session.rollback()
+            else:
+                log.info("No cache records found for datasource %s", datasource_uid)
 
         def insert_table(event_data: Dict[str, Any]) -> None:
             if not event_data.get("published_name"):

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -5,19 +5,22 @@ import logging
 import time
 from enum import Enum
 import json
+from typing import Optional, Any
+
 import pika
 from sqlalchemy import (
     Column,
     ForeignKey,
     Integer,
 )
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy.exc import NoSuchTableError, SQLAlchemyError
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.schema import UniqueConstraint
 from flask import current_app
 from flask_appbuilder import Model
+
 from superset.app import create_app
 app = create_app()
 app.app_context().push()
@@ -25,6 +28,8 @@ from superset import app, db, security_manager
 from superset.connectors.sqla.models import SqlaTable, Database, SqlMetric
 from superset.models.core import Database
 from superset.models.slice import Slice
+from superset.models.cache import CacheKey
+from superset.extensions import cache_manager
 
 
 log = logging.getLogger(__name__)
@@ -40,7 +45,7 @@ Role = security_manager.role_model
 class BaseEnum(Enum):
     # TODO: Figure out how to avoid copy/pasting this class (and subclasses) from plaid.
     # maybe add it to plaidtools somehow?
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
 
@@ -73,7 +78,7 @@ class EventType(BaseEnum):
 class EventHandler:
     """Handles plaid-sourced events from a message queue."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Docstring"""
         rmq_connection_info = config.get('RABBITMQ_CONNECTION_INFO', {})
 
@@ -86,7 +91,7 @@ class EventHandler:
         password = rmq_connection_info.get('password', 'cocoa puffs')
         self.credentials = pika.PlainCredentials(username, password)
 
-    def _connect(self):
+    def _connect(self) -> pika.channel.Channel:
         """Docstring"""
         connection = pika.BlockingConnection(
             pika.ConnectionParameters(
@@ -99,7 +104,7 @@ class EventHandler:
         )
         return connection.channel()
 
-    def consume(self):
+    def consume(self) -> None:
         """Docstring"""
         channel = self._connect()
         for method, _, body in channel.consume(self.queue, inactivity_timeout=1): # pylint: disable=unused-variable
@@ -111,7 +116,7 @@ class EventHandler:
             channel.basic_ack(method.delivery_tag)
             self.process_event(data)
 
-    def process_event(self, info):
+    def process_event(self, info: dict[str, Any]) -> None:
         try:
             event_type = EventType(info['event'])
             object_type = PlaidObjectType(info['type'])
@@ -128,14 +133,22 @@ class EventHandler:
                 # PlaidObjectType.User: self._handle_user_event,
             }
 
+            # View should work because every time we change the query for a view, we run table.update()
+            #   Oh, except, if there's an ancestor that changes that wouldn't work. Hmm.
+            #   I'm supposed to not worry about this unless it's easy
+
+            # Paul says that on every table change things are unpublished and republished. If that's so, I should be able
+            #   to hook into that.
+            #   It seems like every table extract runs an update_shape, which runs an object_tools.save_object (gst.save_object), which runs a _set_object_cache, which publishes either an Update event or a Create event
+
             handle_event = event_handlers.get(object_type, self._handle_passthrough)
 
             handle_event(event_type, data, **kwargs)
         except ValueError:
             # Skip this event as it is not recognized.
-            self._handle_passthrough(None, None)
+            self._handle_passthrough(event_type, {})
 
-    def _handle_workspace_event(self, event_type, data, **kwargs):
+    def _handle_workspace_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
         if event_type is EventType.Create:
             # Create events would be a no-op here, so ignore them.
             pass
@@ -151,8 +164,8 @@ class EventHandler:
 
         db.session.commit()
 
-    def _handle_project_event(self, event_type, data, **kwargs):
-        def map_data_to_row(event_data, existing_project=None):
+    def _handle_project_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
+        def map_data_to_row(event_data: dict[str, Any], existing_project: Optional[Database] = None) -> Database:
             if isinstance(existing_project, Database):
                 proj = existing_project
             else:
@@ -176,7 +189,7 @@ class EventHandler:
 
             return proj
 
-        def insert_project(event_data):
+        def insert_project(event_data: dict[str, Any]) -> None:
             if not db.session.query(db.session.query(Database).filter_by(uuid=event_data['id']).exists()).scalar():
                 # Project doesn't exist, so make a new one.
                 log.info(f"Inserting project {event_data['name']} ({event_data['id']}).")
@@ -187,7 +200,7 @@ class EventHandler:
                 # TODO: Log a warning here. No project should exist.
                 update_project(event_data)
 
-        def update_project(event_data):
+        def update_project(event_data: dict[str, Any]) -> None:
             try:
                 log.info(f"Updating project {event_data['name']} ({event_data['id']}).")
                 existing_project = db.session.query(Database).filter_by(uuid=event_data['id']).one()
@@ -198,7 +211,7 @@ class EventHandler:
                 map_data_to_row(event_data, existing_project)
                 db.session.commit()
 
-        def delete_project(event_data):
+        def delete_project(event_data: dict[str, Any]) -> None:
             # TODO: Deleting a table associated with a chart breaks UI (can't set new datasource, can only delete chart)
             # Need to figure out how to handle this circumstance (delete charts too? update dataousrce to placeholder?)
             # If update to placeholder, how to regulate perms?
@@ -217,9 +230,9 @@ class EventHandler:
         elif event_type is EventType.Delete:
             delete_project(data)
 
-    def _handle_table_event(self, event_type, data, **kwargs):
+    def _handle_table_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
 
-        def map_data_to_row(event_data, existing_table=None):
+        def map_data_to_row(event_data: dict[str, Any], existing_table: Optional[SqlaTable] = None) -> SqlaTable:
             if isinstance(existing_table, SqlaTable):
                 table = existing_table
             else:
@@ -232,7 +245,43 @@ class EventHandler:
 
             return table
 
-        def insert_table(event_data):
+        def clear_table_cache(datasource_uid: str) -> None:
+            # Copied from superset/cachekeys/api.py
+            cache_key_objs = (
+                db.session.query(CacheKey)
+                .filter(CacheKey.datasource_uid == datasource_uid)
+                .all()
+            )
+            cache_keys = [c.cache_key for c in cache_key_objs]
+            if cache_keys:
+                all_keys_deleted = cache_manager.cache.delete_many(*cache_keys)
+
+                if not all_keys_deleted:
+                    # expected behavior as keys may expire and cache is not a
+                    # persistent storage
+                    log.info(
+                        "Some of the cache keys were not deleted in the list %s", cache_keys
+                    )
+
+                try:
+                    delete_stmt = (
+                        CacheKey.__table__.delete().where(  # pylint: disable=no-member
+                            CacheKey.cache_key.in_(cache_keys)
+                        )
+                    )
+                    db.session.execute(delete_stmt)
+                    db.session.commit()
+
+                    log.info(
+                        "Invalidated %s cache records for datasource %s",
+                        len(cache_keys),
+                        datasource_uid,
+                    )
+                except SQLAlchemyError as ex:  # pragma: no cover
+                    log.error(ex, exc_info=True)
+                    db.session.rollback()
+
+        def insert_table(event_data: dict[str, Any]) -> None:
             if not event_data.get("published_name"):
                 log.info(
                     f"Received table insert event for {event_data['id']} "
@@ -242,50 +291,57 @@ class EventHandler:
                 return
             log.info(f"Inserting table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
             log.info(f"{event_data['id'].replace('analyzetable_', '')}")
+
             if not db.session.query(
                 db.session.query(SqlaTable).filter_by(
-                        uuid=event_data['id'].replace('analyzetable_', ''),
-                    ).exists()
-                ).scalar():
-                # Table doesn't exist, so make a new one.
-                try:
-                    new_table = map_data_to_row(event_data)
-                    log.info(f"{new_table.database_id}")
-
-                    # Test if source table/view actually exists before we add it.
-                    try:
-                        project = db.session.query(Database).filter_by(uuid=kwargs['project_id']).one()
-                        log.info(project.get_all_view_names_in_schema(schema=new_table.schema))
-                        # TODO: This is pretty dumb. Event is being processed before the DB can create the view.
-                        time.sleep(2)
-                        project.get_table(table_name=new_table.table_name, schema=new_table.schema)
-                        new_table.database = project
-                    except (NoResultFound, NoSuchTableError):
-                        log.warning(f"Table {new_table.schema}.{new_table.table_name} doesn't exist. Skipping.")
-                        return
-
-                    # If we've made it this far, the source table/view exists.
-                    db.session.add(new_table)
-                    db.session.commit()
-
-                    # Populate columns and metrics for table.
-                    new_table.fetch_metadata()
-
-                    db.session.commit()
-                except Exception:
-                    log.exception("Error occurred while inserting a new table.")
-                    db.session.rollback()
-                    return
-            else:
+                    uuid=event_data['id'].replace('analyzetable_', ''),
+                ).exists()
+            ).scalar():
                 log.warning("Received a create event for a table, but the table already exists.")
                 update_table(event_data)
+                return
 
-        def update_table(event_data):
+            # Table doesn't exist, so make a new one.
+            try:
+                new_table = map_data_to_row(event_data)
+                log.info(f"{new_table.database_id}")
+
+                # Test if source table/view actually exists before we add it.
+                try:
+                    project = db.session.query(Database).filter_by(uuid=kwargs['project_id']).one()
+                    log.info(project.get_all_view_names_in_schema(schema=new_table.schema))
+                    # TODO: This is pretty dumb. Event is being processed before the DB can create the view.
+                    time.sleep(2)
+                    project.get_table(table_name=new_table.table_name, schema=new_table.schema)
+                    new_table.database = project
+                except (NoResultFound, NoSuchTableError):
+                    log.warning(f"Table {new_table.schema}.{new_table.table_name} doesn't exist. Skipping.")
+                    return
+
+                # If we've made it this far, the source table/view exists.
+                db.session.add(new_table)
+                db.session.commit()
+
+                # Populate columns and metrics for table.
+                new_table.fetch_metadata()
+
+                db.session.commit()
+
+                clear_table_cache(new_table.uid)
+
+            except Exception:
+                log.exception("Error occurred while inserting a new table.")
+                db.session.rollback()
+                return
+
+
+        def update_table(event_data: dict[str, Any]) -> None:
             try:
                 log.info(f"Updating table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
                 existing_table = db.session.query(SqlaTable).filter_by(
                     uuid=event_data['id'].replace('analyzetable_', ''),
                 ).one()
+
                 if not event_data.get("published_name"):
                     # !! We don't do this any more because sometimes there are multiple tables with the same published name !!
                     # !! Things may seriously break if this code is uncommented. !!
@@ -294,11 +350,15 @@ class EventHandler:
                     # log.info(f"Table {event_data['published_name']} ({event_data['id']}) has no published name, and will be deleted.")
                     # delete_table(event_data)
                     return
+
                 map_data_to_row(event_data, existing_table)
                 # TODO: This is pretty dumb. Event is being processed before the DB can create the view.
                 time.sleep(2)
                 existing_table.fetch_metadata()
                 db.session.commit()
+
+                clear_table_cache(existing_table.uid)
+
             except NoResultFound:
                 log.warning("Received an update event for a table that doesn't exist.")
                 insert_table(event_data)
@@ -306,7 +366,7 @@ class EventHandler:
                 log.exception("Error occurred while updating a table.")
                 db.session.rollback()
 
-        def delete_table(event_data):
+        def delete_table(event_data: dict[str, Any]) -> None:
             try:
                 log.info(f"Deleting table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
                 table = db.session.query(SqlaTable).filter(
@@ -329,6 +389,7 @@ class EventHandler:
                     security_manager.del_permission_view_menu('datasource_access', table.get_perm())
                     db.session.delete(table)
                     db.session.commit()
+                    clear_table_cache(table.uid)
             except NoResultFound:
                 log.warning("Received a delete event for a table that doesn't exist.")
             except Exception:
@@ -344,10 +405,12 @@ class EventHandler:
             log.warning(f"Received a delete event for table {data['published_name']}, but deleting tables through events is no longer permitted.")
 
     # TODO: Do we even care about views here? Are views what I think they are?
-    def _handle_view_event(self, event_type, data, **kwargs):
+    #       ADT2022 - I don't think we do. I think that when the things we care about happen to views, a table
+    #       event is published.
+    def _handle_view_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
         raise NotImplementedError()
 
-    def _handle_passthrough(self, event_type, data, **kwargs):
+    def _handle_passthrough(self, event_type: Optional[EventType], data: Optional[dict[str, Any]], **kwargs: Any) -> None:
         # TODO: Should we debug log unhandled events?
         pass
 

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -354,12 +354,12 @@ class EventHandler:
                     return
 
                 map_data_to_row(event_data, existing_table)
+                clear_table_cache(existing_table.uid)
+
                 # TODO: This is pretty dumb. Event is being processed before the DB can create the view.
                 time.sleep(2)
                 existing_table.fetch_metadata()
                 db.session.commit()
-
-                clear_table_cache(existing_table.uid)
 
             except NoResultFound:
                 log.warning("Received an update event for a table that doesn't exist.")

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -294,7 +294,7 @@ class EventHandler:
             log.info(f"Inserting table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
             log.info(f"{event_data['id'].replace('analyzetable_', '')}")
 
-            if not db.session.query(
+            if db.session.query(
                 db.session.query(SqlaTable).filter_by(
                     uuid=event_data['id'].replace('analyzetable_', ''),
                 ).exists()
@@ -340,30 +340,32 @@ class EventHandler:
         def update_table(event_data: Dict[str, Any]) -> None:
             try:
                 log.info(f"Updating table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
-                existing_table = db.session.query(SqlaTable).filter_by(
-                    uuid=event_data['id'].replace('analyzetable_', ''),
-                ).one()
+                try:
+                    existing_table = db.session.query(SqlaTable).filter_by(
+                        uuid=event_data['id'].replace('analyzetable_', ''),
+                    ).one()
+                except NoResultFound:
+                    log.warning("Received an update event for a table that doesn't exist.")
+                    insert_table(event_data)
+                else:
 
-                if not event_data.get("published_name"):
-                    # !! We don't do this any more because sometimes there are multiple tables with the same published name !!
-                    # !! Things may seriously break if this code is uncommented. !!
+                    if not event_data.get("published_name"):
+                        # !! We don't do this any more because sometimes there are multiple tables with the same published name !!
+                        # !! Things may seriously break if this code is uncommented. !!
 
-                    # # Table still exists, but the user unpublished it. So we want to delete.
-                    # log.info(f"Table {event_data['published_name']} ({event_data['id']}) has no published name, and will be deleted.")
-                    # delete_table(event_data)
-                    return
+                        # # Table still exists, but the user unpublished it. So we want to delete.
+                        # log.info(f"Table {event_data['published_name']} ({event_data['id']}) has no published name, and will be deleted.")
+                        # delete_table(event_data)
+                        return
 
-                map_data_to_row(event_data, existing_table)
-                clear_table_cache(existing_table.uid)
+                    map_data_to_row(event_data, existing_table)
+                    clear_table_cache(existing_table.uid)
 
-                # TODO: This is pretty dumb. Event is being processed before the DB can create the view.
-                time.sleep(2)
-                existing_table.fetch_metadata()
-                db.session.commit()
+                    # TODO: This is pretty dumb. Event is being processed before the DB can create the view.
+                    time.sleep(2)
+                    existing_table.fetch_metadata()
+                    db.session.commit()
 
-            except NoResultFound:
-                log.warning("Received an update event for a table that doesn't exist.")
-                insert_table(event_data)
             except Exception:
                 log.exception("Error occurred while updating a table.")
                 db.session.rollback()

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -253,35 +253,35 @@ class EventHandler:
                 .all()
             )
             cache_keys = [c.cache_key for c in cache_key_objs]
-            if cache_keys:
-                all_keys_deleted = cache_manager.cache.delete_many(*cache_keys)
-
-                if not all_keys_deleted:
-                    # expected behavior as keys may expire and cache is not a
-                    # persistent storage
-                    log.info(
-                        "Some of the cache keys were not deleted in the list %s", cache_keys
-                    )
-
-                try:
-                    delete_stmt = (
-                        CacheKey.__table__.delete().where(  # pylint: disable=no-member
-                            CacheKey.cache_key.in_(cache_keys)
-                        )
-                    )
-                    db.session.execute(delete_stmt)
-                    db.session.commit()
-
-                    log.info(
-                        "Invalidated %s cache records for datasource %s",
-                        len(cache_keys),
-                        datasource_uid,
-                    )
-                except SQLAlchemyError as ex:  # pragma: no cover
-                    log.error(ex, exc_info=True)
-                    db.session.rollback()
-            else:
+            if not cache_keys:
                 log.info("No cache records found for datasource %s", datasource_uid)
+                return
+
+            all_keys_deleted = cache_manager.cache.delete_many(*cache_keys)
+            if not all_keys_deleted:
+                # expected behavior as keys may expire and cache is not a
+                # persistent storage
+                log.info(
+                    "Some of the cache keys were not deleted in the list %s", cache_keys
+                )
+
+            try:
+                delete_stmt = (
+                    CacheKey.__table__.delete().where(  # pylint: disable=no-member
+                        CacheKey.cache_key.in_(cache_keys)
+                    )
+                )
+                db.session.execute(delete_stmt)
+                db.session.commit()
+
+                log.info(
+                    "Invalidated %s cache records for datasource %s",
+                    len(cache_keys),
+                    datasource_uid,
+                )
+            except SQLAlchemyError as ex:  # pragma: no cover
+                log.error(ex, exc_info=True)
+                db.session.rollback()
 
         def insert_table(event_data: Dict[str, Any]) -> None:
             if not event_data.get("published_name"):

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -5,7 +5,7 @@ import logging
 import time
 from enum import Enum
 import json
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 import pika
 from sqlalchemy import (
@@ -116,7 +116,7 @@ class EventHandler:
             channel.basic_ack(method.delivery_tag)
             self.process_event(data)
 
-    def process_event(self, info: dict[str, Any]) -> None:
+    def process_event(self, info: Dict[str, Any]) -> None:
         try:
             event_type = EventType(info['event'])
             object_type = PlaidObjectType(info['type'])
@@ -148,7 +148,7 @@ class EventHandler:
             # Skip this event as it is not recognized.
             self._handle_passthrough(event_type, {})
 
-    def _handle_workspace_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
+    def _handle_workspace_event(self, event_type: EventType, data: Dict[str, Any], **kwargs: Any) -> None:
         if event_type is EventType.Create:
             # Create events would be a no-op here, so ignore them.
             pass
@@ -164,8 +164,8 @@ class EventHandler:
 
         db.session.commit()
 
-    def _handle_project_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
-        def map_data_to_row(event_data: dict[str, Any], existing_project: Optional[Database] = None) -> Database:
+    def _handle_project_event(self, event_type: EventType, data: Dict[str, Any], **kwargs: Any) -> None:
+        def map_data_to_row(event_data: Dict[str, Any], existing_project: Optional[Database] = None) -> Database:
             if isinstance(existing_project, Database):
                 proj = existing_project
             else:
@@ -189,7 +189,7 @@ class EventHandler:
 
             return proj
 
-        def insert_project(event_data: dict[str, Any]) -> None:
+        def insert_project(event_data: Dict[str, Any]) -> None:
             if not db.session.query(db.session.query(Database).filter_by(uuid=event_data['id']).exists()).scalar():
                 # Project doesn't exist, so make a new one.
                 log.info(f"Inserting project {event_data['name']} ({event_data['id']}).")
@@ -200,7 +200,7 @@ class EventHandler:
                 # TODO: Log a warning here. No project should exist.
                 update_project(event_data)
 
-        def update_project(event_data: dict[str, Any]) -> None:
+        def update_project(event_data: Dict[str, Any]) -> None:
             try:
                 log.info(f"Updating project {event_data['name']} ({event_data['id']}).")
                 existing_project = db.session.query(Database).filter_by(uuid=event_data['id']).one()
@@ -211,7 +211,7 @@ class EventHandler:
                 map_data_to_row(event_data, existing_project)
                 db.session.commit()
 
-        def delete_project(event_data: dict[str, Any]) -> None:
+        def delete_project(event_data: Dict[str, Any]) -> None:
             # TODO: Deleting a table associated with a chart breaks UI (can't set new datasource, can only delete chart)
             # Need to figure out how to handle this circumstance (delete charts too? update dataousrce to placeholder?)
             # If update to placeholder, how to regulate perms?
@@ -230,9 +230,9 @@ class EventHandler:
         elif event_type is EventType.Delete:
             delete_project(data)
 
-    def _handle_table_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
+    def _handle_table_event(self, event_type: EventType, data: Dict[str, Any], **kwargs: Any) -> None:
 
-        def map_data_to_row(event_data: dict[str, Any], existing_table: Optional[SqlaTable] = None) -> SqlaTable:
+        def map_data_to_row(event_data: Dict[str, Any], existing_table: Optional[SqlaTable] = None) -> SqlaTable:
             if isinstance(existing_table, SqlaTable):
                 table = existing_table
             else:
@@ -281,7 +281,7 @@ class EventHandler:
                     log.error(ex, exc_info=True)
                     db.session.rollback()
 
-        def insert_table(event_data: dict[str, Any]) -> None:
+        def insert_table(event_data: Dict[str, Any]) -> None:
             if not event_data.get("published_name"):
                 log.info(
                     f"Received table insert event for {event_data['id']} "
@@ -335,7 +335,7 @@ class EventHandler:
                 return
 
 
-        def update_table(event_data: dict[str, Any]) -> None:
+        def update_table(event_data: Dict[str, Any]) -> None:
             try:
                 log.info(f"Updating table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
                 existing_table = db.session.query(SqlaTable).filter_by(
@@ -366,7 +366,7 @@ class EventHandler:
                 log.exception("Error occurred while updating a table.")
                 db.session.rollback()
 
-        def delete_table(event_data: dict[str, Any]) -> None:
+        def delete_table(event_data: Dict[str, Any]) -> None:
             try:
                 log.info(f"Deleting table {event_data['published_name']} ({event_data['id']}) for project {kwargs['project_id']}.")
                 table = db.session.query(SqlaTable).filter(
@@ -407,10 +407,10 @@ class EventHandler:
     # TODO: Do we even care about views here? Are views what I think they are?
     #       ADT2022 - I don't think we do. I think that when the things we care about happen to views, a table
     #       event is published.
-    def _handle_view_event(self, event_type: EventType, data: dict[str, Any], **kwargs: Any) -> None:
+    def _handle_view_event(self, event_type: EventType, data: Dict[str, Any], **kwargs: Any) -> None:
         raise NotImplementedError()
 
-    def _handle_passthrough(self, event_type: Optional[EventType], data: Optional[dict[str, Any]], **kwargs: Any) -> None:
+    def _handle_passthrough(self, event_type: Optional[EventType], data: Optional[Dict[str, Any]], **kwargs: Any) -> None:
         # TODO: Should we debug log unhandled events?
         pass
 

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -160,6 +160,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
         project_id = datasource.schema.replace("report", "")
         rpc = self.get_rpc()
         project = rpc.analyze.project.project(project_id=project_id, keys='id')
+        log.debug(f"result of project query: {project}")
         return bool(project.get('id'))
 
         # log.debug(f"Can access datasource: {datasource}")

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -104,7 +104,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
 
     def get_rpc(self) -> SimpleRPC:
-        log.debug(f"Current user's token is {session['token']['access_token']}")
         base_url = f"http://{self.appbuilder.app.config.get('PLAID_RPC')}"
         rpc_url = urljoin(base_url, "json-rpc/")
 
@@ -153,31 +152,14 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
 
     def can_access_datasource(self, datasource: "BaseDatasource") -> bool:
-        log.debug(f"Checking access to datasource: {datasource}\n\tdatasource.schema: {datasource.schema}")
+        log.debug(f"Checking access to datasource: {datasource}")
         if datasource.schema is None:
             # Call the base method if there is no schema since there isn't a plaid schema.
             return super().can_access_datasource(datasource)
         project_id = datasource.schema.replace("report", "")
         rpc = self.get_rpc()
         project = rpc.analyze.project.project(project_id=project_id)
-        log.debug(f"result of project query: {project}")
         return bool(project.get('id'))
-
-        # log.debug(f"Can access datasource: {datasource}")
-        # if datasource.schema is None:
-        #     # Call the base method if there is no schema since it isn't a plaid table.
-        #     # This was maybe meant to catch the ch10215 issue, but in fact there _is_ a schema in this case
-        #     # Maybe we should be checking based _only_ on access to the project/schema?
-        #     return super().can_access_datasource(datasource)
-        # rpc = self.get_rpc()
-        # table_id = "{}{}".format("analyzetable_", str(datasource.uuid))
-        # table_id_without_dashes = table_id.replace("-", "")
-        # log.debug(f"Fetching table with name: {table_id}")
-        # table = rpc.analyze.table.table(project_id=datasource.schema.replace("report", ""), table_id=table_id)
-        # if table["id"] is None: # This may be legacy - some projects were missing dashes in the UUID.
-        #     table = rpc.analyze.table.table(project_id=datasource.schema.replace("report", ""), table_id=table_id_without_dashes)
-        # log.debug(f"Underlying table for datasource {datasource.uuid}: {table}")
-        # return table.get('id', None) is not None
 
 
     def get_project_ids(self):

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -153,13 +153,13 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
 
     def can_access_datasource(self, datasource: "BaseDatasource") -> bool:
-        log.debug(f"Checking access to datasource: {datasource}")
+        log.debug(f"Checking access to datasource: {datasource}\n\tdatasource.schema: {datasource.schema}")
         if datasource.schema is None:
             # Call the base method if there is no schema since there isn't a plaid schema.
             return super().can_access_datasource(datasource)
         project_id = datasource.schema.replace("report", "")
         rpc = self.get_rpc()
-        project = rpc.analyze.project.project(project_id=project_id, keys='id')
+        project = rpc.analyze.project.project(project_id=project_id)
         log.debug(f"result of project query: {project}")
         return bool(project.get('id'))
 

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -153,19 +153,30 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
 
     def can_access_datasource(self, datasource: "BaseDatasource") -> bool:
-        log.debug(f"Can access datasource: {datasource}")
+        log.debug(f"Checking access to datasource: {datasource}")
         if datasource.schema is None:
-            # Call the base method if there is no schema since it isn't a plaid table.
+            # Call the base method if there is no schema since there isn't a plaid schema.
             return super().can_access_datasource(datasource)
+        project_id = datasource.schema.replace("report", "")
         rpc = self.get_rpc()
-        table_id = "{}{}".format("analyzetable_", str(datasource.uuid))
-        table_id_without_dashes = table_id.replace("-", "")
-        log.debug(f"Fetching table with name: {table_id}")
-        table = rpc.analyze.table.table(project_id=datasource.schema.replace("report", ""), table_id=table_id)
-        if table["id"] is None: # This may be legacy - some projects were missing dashes in the UUID.
-            table = rpc.analyze.table.table(project_id=datasource.schema.replace("report", ""), table_id=table_id_without_dashes)
-        log.debug(f"Underlying table for datasource {datasource.uuid}: {table}")
-        return table.get('id', None) is not None
+        project = rpc.analyze.project.project(project_id=project_id, keys='id')
+        return bool(project.get('id'))
+
+        # log.debug(f"Can access datasource: {datasource}")
+        # if datasource.schema is None:
+        #     # Call the base method if there is no schema since it isn't a plaid table.
+        #     # This was maybe meant to catch the ch10215 issue, but in fact there _is_ a schema in this case
+        #     # Maybe we should be checking based _only_ on access to the project/schema?
+        #     return super().can_access_datasource(datasource)
+        # rpc = self.get_rpc()
+        # table_id = "{}{}".format("analyzetable_", str(datasource.uuid))
+        # table_id_without_dashes = table_id.replace("-", "")
+        # log.debug(f"Fetching table with name: {table_id}")
+        # table = rpc.analyze.table.table(project_id=datasource.schema.replace("report", ""), table_id=table_id)
+        # if table["id"] is None: # This may be legacy - some projects were missing dashes in the UUID.
+        #     table = rpc.analyze.table.table(project_id=datasource.schema.replace("report", ""), table_id=table_id_without_dashes)
+        # log.debug(f"Underlying table for datasource {datasource.uuid}: {table}")
+        # return table.get('id', None) is not None
 
 
     def get_project_ids(self):

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2099,6 +2099,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             # update changed_on timestamp
             session.execute(update(NewDataset).where(NewDataset.id == dataset.id))
 
+            logger.info(f'target: {target}\n\ttarget.uuid: {target.uuid}')
             # update `Column` model as well
             session.add(
                 target.to_sl_column(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1897,6 +1897,8 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 logger.info(f"old column exists for {new_column} - new_column.uuid: {new_column.uuid}")
             new_column.groupby = True
             new_column.filterable = True
+            if not new_column.uuid:
+                new_column.uuid = uuid4()
             columns.append(new_column)
             if not any_date_col and new_column.is_temporal:
                 any_date_col = col["name"]

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1901,6 +1901,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
         # add back calculated (virtual) columns
         columns.extend([col for col in old_columns if col.expression])
+        logger.info(f"Setting columns to: {columns}\n\tuuids:{[col.uuid for col in columns]}")
         self.columns = columns
 
         metrics.append(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1887,14 +1887,12 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 )
                 new_column.is_dttm = new_column.is_temporal
                 db_engine_spec.alter_new_orm_column(new_column)
-                logger.info(f"no old column for {new_column} - new_column.uuid: {new_column.uuid}")
             else:
                 new_column = old_column
                 if new_column.type != col["type"]:
                     results.modified.append(col["name"])
                 new_column.type = col["type"]
                 new_column.expression = ""
-                logger.info(f"old column exists for {new_column} - new_column.uuid: {new_column.uuid}")
             new_column.groupby = True
             new_column.filterable = True
             if not new_column.uuid:
@@ -1905,7 +1903,6 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
         # add back calculated (virtual) columns
         columns.extend([col for col in old_columns if col.expression])
-        logger.info(f"Setting columns to: {columns}\n\tuuids:{[col.uuid for col in columns]}")
         self.columns = columns
 
         metrics.append(
@@ -2104,7 +2101,6 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             # update changed_on timestamp
             session.execute(update(NewDataset).where(NewDataset.id == dataset.id))
 
-            logger.info(f'target: {target}\n\ttarget.uuid: {target.uuid}')
             # update `Column` model as well
             session.add(
                 target.to_sl_column(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1887,12 +1887,14 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 )
                 new_column.is_dttm = new_column.is_temporal
                 db_engine_spec.alter_new_orm_column(new_column)
+                logger.info(f"no old column for {new_column} - new_column.uuid: {new_column.uuid}")
             else:
                 new_column = old_column
                 if new_column.type != col["type"]:
                     results.modified.append(col["name"])
                 new_column.type = col["type"]
                 new_column.expression = ""
+                logger.info(f"old column exists for {new_column} - new_column.uuid: {new_column.uuid}")
             new_column.groupby = True
             new_column.filterable = True
             columns.append(new_column)


### PR DESCRIPTION
This resolves https://app.shortcut.com/plaidcloud/story/10150/add-ss-cache-invalidation-to-events-processing and https://app.shortcut.com/plaidcloud/story/10215/bug-cannot-use-a-dataset-in-ss-that-is-based-on-a-saved-query

It also fixes a bug in which TableColumns sometimes had no uuid, which was causing update_table to error.