### PR TITLE
Upgrade events python to 3.10 and also fix a small bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ######################################################################
 # PY stage that simply does a pip install on our requirements
 ######################################################################
-ARG PY_VER=3.8.12
+ARG PY_VER=3.10
 FROM python:${PY_VER} AS superset-py
 
 RUN mkdir /app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ######################################################################
 # PY stage that simply does a pip install on our requirements
 ######################################################################
-ARG PY_VER=3.10
+ARG PY_VER=3.8.12
 FROM python:${PY_VER} AS superset-py
 
 RUN mkdir /app \

--- a/Dockerfile.events
+++ b/Dockerfile.events
@@ -1,4 +1,4 @@
-ARG PY_VER=3.8.12
+ARG PY_VER=3.10
 FROM python:${PY_VER} AS build-distribution
 
 ENV LANG=C.UTF-8 \

--- a/plaid/event_handler.py
+++ b/plaid/event_handler.py
@@ -79,7 +79,7 @@ class MissingDataException(Exception):
     def __init__(self, event_data: Dict[str, Any], required_keys: Collection[str]) -> None:
         self.event_data = event_data
         self.required_keys = required_keys
-        self.missing_keys = [key for key in self.required_keys if key not in self.event_data]
+        self.missing_keys = [key for key in self.required_keys if not self.event_data.get(key)]
         self.message = f"Event data is missing required fields {self.missing_keys}:\n\t {self.event_data}"
         super().__init__(self.message)
 


### PR DESCRIPTION
Upgrading events because we have complete control over it. Not upgrading superset yet so we don't have to worry about compatibility.

(this upgrade was necessary because the previous PR unknowingly used a 3.10 feature - so it was either rewrite it the deprecated way or upgrade to 3.10)