### PR TITLE
Validate oauth token using before_request

### DIFF
--- a/plaid/security.py
+++ b/plaid/security.py
@@ -32,6 +32,7 @@ __email__ = "garrett.bates@tartansolutions.com"
 
 
 log = logging.getLogger(__name__)
+USE_REFRESH_TOKENS = False
 
 
 def get_project_role_name(project_id: str) -> str:
@@ -390,24 +391,75 @@ class PlaidSecurityManager(SupersetSecurityManager):
                 "Appended %s to %s roles list.", role.name, user.username
             )
 
-    def has_access(self, permission_name: str, view_name: str) -> bool:
-        # check token expiry and logout, then continue previous auth check
+    def set_oauth_session(self, provider, oauth_response):
+        """
+        Set the current session with OAuth token dict
+        """
+        # Save users token_dict on encrypted session cookie
+        if USE_REFRESH_TOKENS:
+            session["oauth_token_dict"] = oauth_response
+        super().set_oauth_session(provider, oauth_response)
+
+    def has_oauth_token(self):
         if self.auth_type == AUTH_OAUTH:
-            if 'oauth' in session:
-                token, secret = session['oauth']
-                # provider = session["oauth_provider"]
-                if not token_is_valid(token):
-                    logout_user()
-                    session.clear()
+            return 'oauth' in session
+        if self.auth_type == AUTH_OID:
+            return 'token' in session
+        return False
 
-        elif self.auth_type == AUTH_OID:
-            if 'token' in session:
-                token = session['token']
-                if not token_is_valid(token):
-                    logout_user()
-                    session.clear()
+    def validate_oauth_token(self):
+        def _internal_validate():
+            try:
+                if self.auth_type == AUTH_OAUTH:
+                    if 'oauth' in session:
+                        # Basic validation of token expiry
+                        token, secret = session['oauth']
+                        if token_is_valid(token):
+                            return True
 
-        return super().has_access(permission_name, view_name)
+                        if USE_REFRESH_TOKENS:
+                            # to do the below, it needs custom `set_oauth_session` to save the `oauth_token_dict`
+                            provider = session["oauth_provider"]
+                            token_dict = session['oauth_token_dict']
+                            logging.info('Provider %s, Token %s', provider, token_dict)
+                            # this will refresh the token if it is expired (via `token_update` listener)
+                            self.appbuilder.sm.oauth_remotes[provider].token = token_dict
+                            user_resp = self.appbuilder.sm.oauth_remotes[provider].get("userinfo")
+                            user_resp.raise_for_status()
+                            logging.info('Got user response')
+                            # ToDo - probably should check token now refreshed, or use the introspection
+
+                            #ToDo - I could not get introspection to work, I was calling from FlaskOAuth2App, but needs to be and OAuth2Session which is the _get_oauth_client() of the Flask thing
+                            # maybe we don't need to introspect anyway, can just check expiry.
+
+                            # # new token now stored in session
+                            # token_dict = session['oauth_token_dict']
+                            # logging.info('Provider %s, Revised Token %s', provider, token_dict)
+                            # token_endpoint = self.appbuilder.sm.oauth.plaidkeycloak.access_token_url
+                            # intro_resp = self.appbuilder.sm.oauth_remotes[provider].introspect_token(token_endpoint, token=token_dict)
+                            # intro_resp.raise_for_status()
+                            # logging.info('Did introspection')
+                            # token_info = intro_resp.json()
+                            # if token_info['active']:
+                            #     return True
+
+                elif self.auth_type == AUTH_OID:
+                    if 'token' in session:
+                        token = session['token']
+                        if token_is_valid(token):
+                            return True
+
+                return False
+
+            except Exception as e:
+                logging.exception('Failed to validate oauth token: %s', e)
+                return False
+
+        result = _internal_validate()
+        if not result:
+            logout_user()
+            session.clear()
+        return result
 
 
 def token_is_valid(access_token):


### PR DESCRIPTION
Using the FLASK_APP_MUTATOR in the superset config, we implement a `before_request` hook that calls the `has_oauth_token` and `validate_oauth_token` methods in this security manager.

If USE_REFRESH_TOKENS is set to True, it should use authlib to refresh the token, but since our access_token lifespan is the same as the refresh token at the moment, this seems unnecessary so I turned it off and it is probably missing a little validation after updating the token.