### PR TITLE
Fix MCP OAuth base_url to host root (drop doubled /mcp)

### DIFF
--- a/plaid/mcp_oauth.py
+++ b/plaid/mcp_oauth.py
@@ -105,7 +105,12 @@ def build_mcp_auth_factory(app: Any) -> Any:
         from fastmcp.server.auth.oauth_proxy import OAuthProxy
 
         service_url = (app.config.get('MCP_SERVICE_URL') or '').rstrip('/')
-        base_url = app.config.get('MCP_OAUTH_BASE_URL') or f'{service_url}/mcp'
+        # base_url is the host root, NOT the /mcp endpoint. FastMCP appends the
+        # transport mount path (/mcp) itself when it derives the resource URL and
+        # the .well-known discovery routes (resource_url = base_url + mcp_path).
+        # Passing '<host>/mcp' here double-counts the mount and advertises a
+        # bogus resource of '<host>/mcp/mcp', which strict MCP clients reject.
+        base_url = app.config.get('MCP_OAUTH_BASE_URL') or service_url
         if not base_url.lower().startswith(('http://', 'https://')):
             log.error(
                 'MCP OAuth proxy needs an absolute MCP_SERVICE_URL/'
@@ -137,7 +142,7 @@ def build_mcp_auth_factory(app: Any) -> Any:
             forward_pkce=True,
             token_verifier=verifier,
             base_url=base_url,
-            # Resolves under base_url (.../mcp/auth/callback); must be a valid
+            # Resolves under base_url (<host>/auth/callback); must be a valid
             # redirect URI on the upstream Keycloak client.
             redirect_path='/auth/callback',
             allowed_client_redirect_uris=LOOPBACK_REDIRECT_URIS,


### PR DESCRIPTION
## Problem

Follow-up to the MCP OAuth discovery work (#332). With the proxy now active in `pw-bugfixes2`, the served Protected Resource Metadata advertises a **doubled path**:

```
GET /.well-known/oauth-protected-resource/mcp/mcp → 200
{"resource":"https://dashboards.bugfixes2.plaidcloud.org/mcp/mcp", ...}
```

The `resource` should be `…/mcp` (where clients connect), not `…/mcp/mcp`. Strict MCP clients reject the mismatched RFC 8707 resource indicator, and the `.well-known` discovery routes get namespaced under `/mcp` instead of the canonical locations.

## Root cause

FastMCP 3.1.0 derives `resource_url = base_url + mcp_path` (`server/auth/auth.py::_get_resource_url`), and `http_app(transport="streamable-http")` mounts the transport at the default `/mcp`. `build_mcp_auth_factory` was passing `base_url = "<host>/mcp"`, so FastMCP appended `/mcp` **again** → `/mcp/mcp`.

## Fix

Set `base_url` to the **host root** (`MCP_SERVICE_URL` without `/mcp`). FastMCP then appends the mount path once:

| | before (`<host>/mcp`) | after (`<host>`) |
|---|---|---|
| resource | `<host>/mcp/mcp` ❌ | `<host>/mcp` ✓ |
| PRM | `/.well-known/oauth-protected-resource/mcp/mcp` | `/.well-known/oauth-protected-resource/mcp` |
| AS metadata | `/.well-known/oauth-authorization-server/mcp` | `/.well-known/oauth-authorization-server` (canonical root) |
| callback | `<host>/auth/callback` | `<host>/auth/callback` (unchanged — already root) |

Operational routes (`/authorize`, `/token`, `/register`, `/revoke`, `/auth/callback`) are registered at root regardless of `base_url` (`create_auth_routes` in FastMCP), so this only corrects the resource indicator and the well-known paths.

Paired with the infra change that routes the canonical discovery + OAuth endpoints to the sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)