### PR TITLE
fix(cli): avoid DetachedInstanceError in compute-thumbnails

### DIFF
--- a/superset/cli/thumbnails.py
+++ b/superset/cli/thumbnails.py
@@ -82,18 +82,21 @@ def compute_thumbnails(
         query = db.session.query(model_cls)
         if model_ids:
             query = query.filter(model_cls.id.in_(model_ids))
-        dashboards = query.all()
-        count = len(dashboards)
-        for i, model in enumerate(dashboards):
-            if asynchronous:
-                func = compute_func.delay
-                action = "Triggering"
-            else:
-                func = compute_func
-                action = "Processing"
-            msg = f'{action} {friendly_type} "{model}" ({i + 1}/{count})'
+        # Materialize the id + label up front. Computing a thumbnail below can
+        # close/expire the session, which detaches the ORM instances and makes
+        # str(model) raise DetachedInstanceError on subsequent iterations.
+        items = [(model.id, str(model)) for model in query.all()]
+        count = len(items)
+        if asynchronous:
+            func = compute_func.delay
+            action = "Triggering"
+        else:
+            func = compute_func
+            action = "Processing"
+        for i, (model_pk, label) in enumerate(items):
+            msg = f'{action} {friendly_type} "{label}" ({i + 1}/{count})'
             click.secho(msg, fg="green")
-            func(None, model.id, force=force)
+            func(None, model_pk, force=force)
 
     if not charts_only:
         compute_generic_thumbnail(


### PR DESCRIPTION
### SUMMARY

`superset compute-thumbnails` raises `DetachedInstanceError` when it processes more than one model (multiple `-i` ids, or all dashboards/charts). Each compute step can close/expire the DB session, detaching the ORM instances returned by `query.all()`. The next loop iteration's progress f-string then calls `str(model)`, which triggers a lazy attribute refresh on a detached instance and crashes.

Fix: materialize `(id, label)` up front so the loop no longer touches detached ORM instances. The executor/action selection is also hoisted out of the loop (it didn't change per-iteration).

### BEFORE/AFTER

**Before** — `superset compute-thumbnails -d -i 8 -i 12` processes the first model, then crashes:
```
sqlalchemy.orm.exc.DetachedInstanceError: Instance <Dashboard at 0x...> is not bound to a Session; attribute refresh operation cannot proceed
```
**After** — all requested models are processed.

### TESTING INSTRUCTIONS

With `THUMBNAILS` enabled and a thumbnail executor configured (e.g. `THUMBNAIL_EXECUTORS = [FixedExecutor("admin")]`), run `superset compute-thumbnails -d` (or with multiple `-i` ids) and confirm every dashboard/chart is processed without the `DetachedInstanceError`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [x] Required feature flags: `THUMBNAILS`
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Small, self-contained bug fix in the CLI — candidate to send upstream to apache/superset as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
