### PR TITLE
fix(security): allow filtering permissions-resources by id (#40293)

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -26,7 +26,11 @@ from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING
 from flask import current_app, Flask, g, Request
 from flask_appbuilder import Model
 from flask_appbuilder.models.filters import BaseFilter
-from flask_appbuilder.security.sqla.apis import RoleApi, UserApi
+from flask_appbuilder.security.sqla.apis import (
+    PermissionViewMenuApi,
+    RoleApi,
+    UserApi,
+)
 from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_appbuilder.security.sqla.models import (
     assoc_group_role,
@@ -185,6 +189,18 @@ class SupersetUserApi(UserApi):
         item.roles = []
 
 
+class SupersetPermissionViewMenuApi(PermissionViewMenuApi):
+    """
+    Overriding PermissionViewMenuApi to allow filtering by `id`.
+
+    FAB's default search_columns for this API omit the `id` primary key, but
+    the Roles UI fetches a role's assigned permissions with a `col:id,opr:in`
+    filter, which FAB then rejects with a 400. See apache/superset#40293.
+    """
+
+    search_columns = ["id", "permission", "view_menu"]
+
+
 # Limiting routes on FAB model views
 PermissionViewModelView.include_route_methods = {RouteMethod.LIST}
 PermissionModelView.include_route_methods = {RouteMethod.LIST}
@@ -267,6 +283,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
     role_api = SupersetRoleApi
     user_api = SupersetUserApi
+    permission_view_menu_api = SupersetPermissionViewMenuApi
 
     USER_MODEL_VIEWS = {
         "RegisterUserModelView",


### PR DESCRIPTION
## Problem

After the v6.1 upgrade, opening any **Role** in the Roles admin page throws **"There was an error loading permissions"**, the permission count flaps between reloads, and permissions render as raw numeric IDs instead of names. Reported on Saputo and USESI; it affects **every tenant on v6.1**.

Root cause is upstream [apache/superset#40293](https://github.com/apache/superset/issues/40293). The Roles UI fetches a role's assigned permissions with:

```
GET /api/v1/security/permissions-resources/?q=(filters:!((col:id,opr:in,value:!(130,136,…))))
```

FAB 5.0.2's `PermissionViewMenuApi` (`resource_name = "security/permissions-resources"`) declares **no `search_columns`**, so FAB auto-derives them from the model and **excludes the `id` primary key** from the filterable set. Filtering by `id` therefore returns `400 {"message":"Filter column: id not allowed to filter"}`, and that single 400 produces all three symptoms (the toast, the flapping count, and the unresolved numeric IDs).

This is **admin-UI-cosmetic only** — it does not affect permission enforcement or RLS.

## Fix

Override `PermissionViewMenuApi` with an explicit `search_columns` that includes `id`, and wire it onto `SupersetSecurityManager`. This mirrors the existing `SupersetUserApi` override in the same file, which already lists `"id"` for the identical reason. The declared list (`["id", "permission", "view_menu"]`) is a strict superset of FAB's auto-derived default (`["permission", "view_menu"]`), so no existing caller loses a filter column.

## Testing / review notes

- `python -c "import ast"` parse OK on the patched file.
- Independent review confirmed against FAB 5.0.2 source: `PermissionViewMenuApi` is importable from `flask_appbuilder.security.sqla.apis`; `permission_view_menu_api` is the correct manager attribute (registered once in `register_views()`); `id` is integer so `opr:in` resolves via `FilterIn`; `"permission"`/`"view_menu"` are valid relationship search columns.
- Out of scope (separate pre-existing bug, same endpoint): the permission-name typeahead in `superset-frontend/src/features/roles/utils.ts` filters by dotted `permission.name`/`view_menu.name`, which FAB can't type-check and 400s regardless — worth a follow-up ticket.

## Promotion

Targets `develop-6.1` (active line). Promote to `beta-6.1` on the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
