### PR TITLE
fix(security): allow filtering permissions-resources by id (#40293) [beta-6.1]

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -26,7 +26,11 @@ from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING
 from flask import current_app, Flask, g, Request
 from flask_appbuilder import Model
 from flask_appbuilder.models.filters import BaseFilter
-from flask_appbuilder.security.sqla.apis import RoleApi, UserApi
+from flask_appbuilder.security.sqla.apis import (
+    PermissionViewMenuApi,
+    RoleApi,
+    UserApi,
+)
 from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_appbuilder.security.sqla.models import (
     assoc_group_role,
@@ -185,6 +189,18 @@ class SupersetUserApi(UserApi):
         item.roles = []
 
 
+class SupersetPermissionViewMenuApi(PermissionViewMenuApi):
+    """
+    Overriding PermissionViewMenuApi to allow filtering by `id`.
+
+    FAB's default search_columns for this API omit the `id` primary key, but
+    the Roles UI fetches a role's assigned permissions with a `col:id,opr:in`
+    filter, which FAB then rejects with a 400. See apache/superset#40293.
+    """
+
+    search_columns = ["id", "permission", "view_menu"]
+
+
 # Limiting routes on FAB model views
 PermissionViewModelView.include_route_methods = {RouteMethod.LIST}
 PermissionModelView.include_route_methods = {RouteMethod.LIST}
@@ -267,6 +283,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
     role_api = SupersetRoleApi
     user_api = SupersetUserApi
+    permission_view_menu_api = SupersetPermissionViewMenuApi
 
     USER_MODEL_VIEWS = {
         "RegisterUserModelView",


### PR DESCRIPTION
Cherry-pick of #338 onto `beta-6.1` so the v6.1 tenant image build picks up the fix.

## Problem
After the v6.1 upgrade, opening any **Role** throws **"There was an error loading permissions"** (raw numeric IDs, flapping counts) across every v6.1 tenant. Root cause is upstream [apache/superset#40293](https://github.com/apache/superset/issues/40293): the Roles UI fetches assigned permissions via `GET /api/v1/security/permissions-resources/?q=(filters:!((col:id,opr:in,…)))`, but FAB 5.0.2's `PermissionViewMenuApi` omits the `id` primary key from `search_columns` → `400 "Filter column: id not allowed to filter"`. Cosmetic admin-UI only; no enforcement/RLS impact.

## Fix
Override `PermissionViewMenuApi` with `search_columns` incl. `id` and wire it onto `SupersetSecurityManager` — identical to the existing `SupersetUserApi` override in the same file. Byte-identical to #338 (merged to `develop-6.1`, `90e06303`), which passed an independent clean-room review verified against FAB 5.0.2 source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
