### PR TITLE
fix(security): filter permissions-resources by related name (sc-23044)

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -26,6 +26,8 @@ from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING
 from flask import current_app, Flask, g, Request
 from flask_appbuilder import Model
 from flask_appbuilder.models.filters import BaseFilter
+from flask_appbuilder.models.sqla.filters import FilterContains, SQLAFilterConverter
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.sqla.apis import (
     PermissionViewMenuApi,
     RoleApi,
@@ -189,16 +191,53 @@ class SupersetUserApi(UserApi):
         item.roles = []
 
 
+class DottedRelationFilterConverter(SQLAFilterConverter):
+    """
+    Resolves dotted relationship columns (e.g. `permission.name`) to a
+    `contains` filter.
+
+    FAB's stock converter type-checks columns via `list_properties[col]`
+    lookups that KeyError on dotted names, so it silently drops them and they
+    can never be filtered. FAB's query engine (`get_field_setup_query`) already
+    joins one level of dotted relation, so a `FilterContains` bound to the
+    dotted name produces correct SQL. See sc-23044.
+    """
+
+    def convert(self, col_name: str) -> Optional[list[BaseFilter]]:
+        if "." in col_name:
+            return [FilterContains(col_name, self.datamodel)]
+        return super().convert(col_name)
+
+
+class SupersetPermissionViewInterface(SQLAInterface):
+    filter_converter_class = DottedRelationFilterConverter
+
+
 class SupersetPermissionViewMenuApi(PermissionViewMenuApi):
     """
-    Overriding PermissionViewMenuApi to allow filtering by `id`.
+    Overriding PermissionViewMenuApi to allow filtering by `id`, and by the
+    related `permission.name` / `view_menu.name` fields.
 
     FAB's default search_columns for this API omit the `id` primary key, but
     the Roles UI fetches a role's assigned permissions with a `col:id,opr:in`
-    filter, which FAB then rejects with a 400. See apache/superset#40293.
+    filter, which FAB then rejects with a 400 (apache/superset#40293).
+
+    The Roles permission typeahead separately searches the related
+    `permission.name` / `view_menu.name` fields (`col:permission.name,opr:ct`).
+    FAB's stock converter can't type-check dotted relationship columns, so it
+    drops them and rejects the filter with the same 400; the dotted-aware
+    converter above resolves them to a join-backed `contains` filter. See
+    sc-23044.
     """
 
-    search_columns = ["id", "permission", "view_menu"]
+    datamodel = SupersetPermissionViewInterface(PermissionView)
+    search_columns = [
+        "id",
+        "permission",
+        "view_menu",
+        "permission.name",
+        "view_menu.name",
+    ]
 
 
 # Limiting routes on FAB model views


### PR DESCRIPTION
Fixes **sc-23044** — the Roles-page permission **typeahead** returns HTTP 400.

## Root cause
`superset-frontend/src/features/roles/utils.ts` (`fetchPermissionOptions`) searches `/api/v1/security/permissions-resources/` by dotted relationship sub-fields: `{col:'permission.name',opr:'ct'}` / `{col:'view_menu.name',opr:'ct'}`. FAB 5.0.2's `SQLAFilterConverter` type-checks columns via `list_properties[col]` lookups that `KeyError` on dotted names (caught → returns `None`), so the column is silently dropped and the filter is rejected with `400`. FAB's *query* engine (`get_field_setup_query`) already joins one level of dotted relation — only the validation/type-introspection layer is dot-blind.

## Fix
Override the API's `datamodel` with `SupersetPermissionViewInterface(SQLAInterface)` whose `filter_converter_class` maps any dotted column to `FilterContains(col, datamodel)`, so dotted columns resolve naturally during normal filter construction. Scoped to this one API's datamodel — the shared `SQLAFilterConverter` is untouched. Additive to the #40293 `id`-filter override in the same class (`col:id,opr:in` still works).

Chosen over poking FAB's private `_filters._search_filters` (also verified working, but reaches internals); `filter_converter_class` is a documented FAB extension point.

## Review / verification
- Verified against FAB 5.0.2 source: `SQLAInterface.filter_converter_class` is instantiated via `Filters(self.filter_converter_class, self)`; `BaseFilterConverter.convert(self, col_name)` with `self.datamodel`; `FilterContains(column_name, datamodel)` joins `Permission`/`ViewMenu` and does `name.ilike('%v%')` (bound param, no injection).
- `apache/superset#39465` is **unrelated** (fixes a 414/429 on assigned-permission hydration, not this dotted-filter 400) — not cited as a fix.
- Plan adversarially reviewed (verdict SOUND) before implementation; full plan on Shortcut sc-23044.

## Follow-up (not in this PR)
Recommended regression test in `tests/unit_tests/security/`: `GET /api/v1/security/permissions-resources/?q=(filters:!((col:permission.name,opr:ct,value:can_read)))` → assert 200 + results contain term, plus `col:id,opr:in` still 200. (Deferred: this fork's CI matrix is baseline-red so a test wouldn't gate today; adding it is tracked on sc-23044.)

## Promotion
`develop-6.1`, then cherry-pick to `beta-6.1` (same as #338/#339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
