### PR TITLE
fix(rls): fail closed when virtual-dataset RLS cannot be applied (sc-23746)

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2071,8 +2071,23 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     from_sql = parsed_script.format()
 
             except Exception as ex:
-                # Log the error but don't fail - RLS application is best-effort
+                # RLS application is a security control, not best-effort. Anything
+                # that raises here (an RLS clause sqlglot cannot parse, a duplicate
+                # dataset over one physical table, a failure re-rendering the SQL)
+                # would otherwise leave ``from_sql`` unfiltered and return every row
+                # to a user entitled to a subset. Fail closed.
                 logger.warning("Failed to apply RLS to virtual dataset SQL: %s", ex)
+                raise SupersetSecurityException(
+                    SupersetError(
+                        error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                        message=_(
+                            "Row level security could not be applied to this "
+                            "virtual dataset, so the query was blocked. Contact "
+                            "an administrator."
+                        ),
+                        level=ErrorLevel.ERROR,
+                    )
+                ) from ex
 
         cte = self.db_engine_spec.get_cte_query(from_sql)
         from_clause = (

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -87,7 +87,13 @@ def get_predicates_for_table(
             SqlaTable.catalog.is_(None),
         )
 
-    dataset = (
+    # Several datasets can point at one physical table: the physical uniqueness
+    # constraint is only (database_id, schema, table_name), and Postgres treats
+    # NULL schemas as distinct, so duplicates are permitted. ``one_or_none()``
+    # raised ``MultipleResultsFound`` here, which callers swallowed into a silently
+    # unfiltered query. Collect the predicates from every matching dataset instead
+    # so the result is deterministic and no rule is dropped.
+    datasets = (
         db.session.query(SqlaTable)
         .filter(
             and_(
@@ -97,9 +103,10 @@ def get_predicates_for_table(
                 SqlaTable.table_name == table.table,
             )
         )
-        .one_or_none()
+        .order_by(SqlaTable.id)
+        .all()
     )
-    if not dataset:
+    if not datasets:
         return []
 
     # Exclude global (unscoped) guest RLS to prevent double application in
@@ -119,6 +126,7 @@ def get_predicates_for_table(
                 compile_kwargs={"literal_binds": True},
             )
         )
+        for dataset in datasets
         for predicate in dataset.get_sqla_row_level_filters(
             include_global_guest_rls=False
         )
@@ -145,26 +153,27 @@ def collect_rls_predicates_for_sql(
     """
     from superset.sql.parse import SQLScript
 
-    try:
-        parsed_script = SQLScript(sql, engine=database.db_engine_spec.engine)
-        tables = {
-            table.qualify(catalog=catalog, schema=schema)
-            for statement in parsed_script.statements
-            for table in statement.tables
+    # Deliberately not wrapped in try/except. Returning ``[]`` on failure produced
+    # the same cache key as a user with no RLS at all, so a restricted user whose
+    # predicate collection failed could hit an unrestricted user's cached rows -
+    # short-circuiting the query, and with it every RLS check downstream. Let the
+    # failure propagate so the request fails closed instead of being served from
+    # someone else's cache entry.
+    parsed_script = SQLScript(sql, engine=database.db_engine_spec.engine)
+    tables = {
+        table.qualify(catalog=catalog, schema=schema)
+        for statement in parsed_script.statements
+        for table in statement.tables
+    }
+    default_catalog = database.get_default_catalog()
+    return sorted(
+        {
+            predicate
+            for table in tables
+            for predicate in get_predicates_for_table(
+                table,
+                database,
+                default_catalog,
+            )
         }
-        default_catalog = database.get_default_catalog()
-        return sorted(
-            {
-                predicate
-                for table in tables
-                for predicate in get_predicates_for_table(
-                    table,
-                    database,
-                    default_catalog,
-                )
-            }
-        )
-    except Exception:
-        # If we can't parse the SQL, return empty list
-        # This ensures RLS application failure doesn't break caching
-        return []
+    )

--- a/tests/unit_tests/models/test_rls_fail_closed.py
+++ b/tests/unit_tests/models/test_rls_fail_closed.py
@@ -139,6 +139,26 @@ class TestDuplicateDatasetsAreDeterministic:
             "c2 = 2",
         ]
 
+    def test_no_matching_dataset_returns_empty(
+        self,
+        mocker: MagicMock,
+    ) -> None:
+        """
+        A physical table with no dataset carries no RLS: return ``[]`` rather
+        than raise. This is not a fail-open path - a table nothing points at
+        has no rules to apply - and it must stay covered so the empty branch
+        does not regress into an exception.
+        """
+        from superset.sql.parse import Table
+        from superset.utils.rls import get_predicates_for_table
+
+        database = mocker.MagicMock()
+        db = mocker.patch("superset.utils.rls.db")
+        db.session.query().filter().order_by().all.return_value = []
+
+        table = Table("t1", "public", "examples")
+        assert get_predicates_for_table(table, database, "examples") == []
+
 
 class TestCacheKeyDoesNotDegrade:
     def test_predicate_collection_failure_propagates(

--- a/tests/unit_tests/models/test_rls_fail_closed.py
+++ b/tests/unit_tests/models/test_rls_fail_closed.py
@@ -1,0 +1,162 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+RLS on virtual datasets must fail closed.
+
+``get_from_clause()`` wrapped its RLS application block in a bare
+``except Exception: logger.warning(...)``. Anything raising inside it left the
+SQL unfiltered and returned every row to a user entitled to a subset, with only
+a log line to show for it. Reproduced against Databend: an RLS clause containing
+an apostrophe (``"col" = 'O'Brien'``) is unparseable, and the query returned
+70,421 rows to a user entitled to 52,145.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+from sqlalchemy.sql.elements import TextClause
+
+from superset.exceptions import SupersetSecurityException
+from superset.models.helpers import ExploreMixin
+
+
+@pytest.fixture
+def virtual_datasource() -> MagicMock:
+    datasource = MagicMock(spec=ExploreMixin)
+    datasource.get_from_clause = ExploreMixin.get_from_clause.__get__(datasource)
+    datasource.text = lambda sql: TextClause(sql)
+    datasource.db_engine_spec.engine = "postgresql"
+    datasource.db_engine_spec.get_cte_query.return_value = None
+    datasource.db_engine_spec.cte_alias = "__cte"
+    datasource.database.get_default_schema.return_value = "public"
+    datasource.catalog = None
+    datasource.schema = "public"
+    datasource.get_rendered_sql.return_value = "SELECT pen_id FROM public.pens"
+    return datasource
+
+
+class TestVirtualDatasetRLSFailsClosed:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            ValueError("Error tokenizing '(\"col\" = 'O'Brien''"),
+            RuntimeError("boom"),
+        ],
+    )
+    def test_apply_rls_failure_raises_instead_of_returning_unfiltered_sql(
+        self,
+        virtual_datasource: MagicMock,
+        app: Flask,
+        error: Exception,
+    ) -> None:
+        """A raise inside the RLS block must block the query, not drop the filter."""
+        with patch("superset.models.helpers.apply_rls", side_effect=error):
+            with pytest.raises(SupersetSecurityException):
+                virtual_datasource.get_from_clause(template_processor=None)
+
+    def test_format_failure_raises(
+        self,
+        virtual_datasource: MagicMock,
+        app: Flask,
+    ) -> None:
+        """A failure re-rendering the SQL must not fall back to unfiltered SQL."""
+        with (
+            patch("superset.models.helpers.apply_rls", return_value=True),
+            patch(
+                "superset.sql.parse.SQLScript.format",
+                side_effect=ValueError("cannot format"),
+            ),
+            pytest.raises(SupersetSecurityException),
+        ):
+            virtual_datasource.get_from_clause(template_processor=None)
+
+    def test_successful_rls_still_returns_from_clause(
+        self,
+        virtual_datasource: MagicMock,
+        app: Flask,
+    ) -> None:
+        """The happy path is unchanged."""
+        with patch("superset.models.helpers.apply_rls", return_value=False):
+            from_clause, cte = virtual_datasource.get_from_clause(
+                template_processor=None
+            )
+        assert cte is None
+        assert "SELECT pen_id FROM public.pens" in str(from_clause.element)
+
+
+class TestDuplicateDatasetsAreDeterministic:
+    def test_predicates_collected_from_every_matching_dataset(
+        self,
+        mocker: MagicMock,
+    ) -> None:
+        """
+        Two datasets over one physical table must not raise
+        ``MultipleResultsFound``; their predicates are combined.
+
+        The physical uniqueness constraint is only
+        ``(database_id, schema, table_name)`` - the four-column constraint
+        declared on the model does not exist in the migrations - and Postgres
+        treats NULL schemas as distinct, so duplicates are permitted.
+        """
+        from superset.sql.parse import Table
+        from superset.utils.rls import get_predicates_for_table
+
+        database = mocker.MagicMock()
+
+        def _dataset(compiled: str) -> MagicMock:
+            predicate = mocker.MagicMock()
+            predicate.compile.return_value = compiled
+            dataset = mocker.MagicMock()
+            dataset.get_sqla_row_level_filters.return_value = [predicate]
+            return dataset
+
+        db = mocker.patch("superset.utils.rls.db")
+        db.session.query().filter().order_by().all.return_value = [
+            _dataset("c1 = 1"),
+            _dataset("c2 = 2"),
+        ]
+
+        table = Table("t1", "public", "examples")
+        assert get_predicates_for_table(table, database, "examples") == [
+            "c1 = 1",
+            "c2 = 2",
+        ]
+
+
+class TestCacheKeyDoesNotDegrade:
+    def test_predicate_collection_failure_propagates(
+        self,
+        mocker: MagicMock,
+    ) -> None:
+        """
+        Returning ``[]`` on failure produced the same cache key as a user with no
+        RLS, letting a restricted user hit an unrestricted user's cached rows.
+        """
+        from superset.utils.rls import collect_rls_predicates_for_sql
+
+        database = mocker.MagicMock()
+        database.db_engine_spec.engine = "postgresql"
+        mocker.patch(
+            "superset.sql.parse.SQLScript.__init__",
+            side_effect=ValueError("unparseable"),
+        )
+
+        with pytest.raises(ValueError, match="unparseable"):
+            collect_rls_predicates_for_sql("SELECT 1", database, "examples", "public")

--- a/tests/unit_tests/security/guest_rls_test.py
+++ b/tests/unit_tests/security/guest_rls_test.py
@@ -222,7 +222,7 @@ def test_scoped_guest_rule_preserved_through_get_predicates_for_table(
     database = mocker.MagicMock()
     database.get_dialect.return_value = sqlite.dialect()
     db = mocker.patch("superset.utils.rls.db")
-    db.session.query().filter().one_or_none.return_value = mock_pd
+    db.session.query().filter().order_by().all.return_value = [mock_pd]
 
     with (
         patch(
@@ -272,7 +272,7 @@ def test_global_guest_rule_excluded_through_get_predicates_for_table(
     database = mocker.MagicMock()
     database.get_dialect.return_value = sqlite.dialect()
     db = mocker.patch("superset.utils.rls.db")
-    db.session.query().filter().one_or_none.return_value = mock_pd
+    db.session.query().filter().order_by().all.return_value = [mock_pd]
 
     with (
         patch(

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -322,7 +322,7 @@ def test_get_predicates_for_table(mocker: MockerFixture) -> None:
     predicate.compile.return_value = "c1 = 1"
     dataset.get_sqla_row_level_filters.return_value = [predicate]
     db = mocker.patch("superset.utils.rls.db")
-    db.session.query().filter().one_or_none.return_value = dataset
+    db.session.query().filter().order_by().all.return_value = [dataset]
 
     table = Table("t1", "public", "examples")
     assert get_predicates_for_table(table, database, "examples") == ["c1 = 1"]


### PR DESCRIPTION
Fixes the silent RLS bypass in [sc-23746](https://app.shortcut.com/plaidcloud/story/23746).

## The bug

`get_from_clause()` wraps its RLS application block in a bare `except Exception: logger.warning(...)` (`superset/models/helpers.py:2073-2075`). Anything raising inside it leaves the virtual dataset SQL **unfiltered** and returns every row to a user entitled to a subset — silently.

Note the story's original headline ("any sqlglot parse failure drops RLS") is **wrong and already corrected**: the vds parse at `helpers.py:2045` sits *outside* the try and fails **closed**. The real bypass is an RLS **clause** sqlglot cannot parse, which the ticket did not originally list.

## Reproduced on bugfixes2

Against Databend on `superset:develop-6.1-365-1` (apache-superset 6.1.0, sqlglot 28.10.0), dataset `publish_test` (70,421 rows), RLS entitling the user to 52,145:

| RLS clause | Result |
|---|---|
| `"PartLevel" = 'Component'` (valid) | 52,145 rows — filtered correctly |
| `"PartLevel" = 'O'Brien'` (apostrophe) | **70,421 rows** — entitled to 52,145 |
| `THIS IS NOT SQL @@@ ((` | **70,421 rows** |
| `"PartLevel" = 'Component' AND` | **70,421 rows** |
| `("PartLevel" = 'Component'` | **70,421 rows** |

The apostrophe case is not synthetic — it is what an interpolated `{{ current_username() }}` produces for a user named `o'brien`, which is exactly the clause shape sc-23724 generates.

## Changes

- **`models/helpers.py`** — re-raise as `SupersetSecurityException` instead of swallowing. The `logger.warning` is kept for alerting. Only datasets that actually have RLS rules reach this path, so the blast radius is limited to queries whose row filtering genuinely failed.
- **`utils/rls.py` / `get_predicates_for_table`** — `one_or_none()` raised `MultipleResultsFound` when two datasets pointed at one physical table. Collect predicates from every matching dataset, ordered by id, so the result is deterministic and no rule is dropped.
- **`utils/rls.py` / `collect_rls_predicates_for_sql`** — returned `[]` on any failure, producing the same cache key as a user with no RLS at all. A restricted user whose predicate collection failed could hit an unrestricted user's cached rows, short-circuiting the query and every RLS check with it. Let the failure propagate.

### Correction to the ticket's constraint analysis

The story asserts the unique constraint `(database_id, catalog, schema, table_name)` at `connectors/sqla/models.py:1236` permits duplicates because Postgres treats NULL catalogs as distinct. That constraint **does not exist physically** — the code comment directly above it says so, and `pg_constraint` on bugfixes2 confirms the real one is:

```
_customer_location_uc = UNIQUE (database_id, schema, table_name)
```

No catalog column. So duplicates are blocked whenever `schema` is non-NULL; the surviving route is NULL `schema`, which Postgres does treat as distinct. `MultipleResultsFound` was reproduced that way, but only by calling `get_predicates_for_table` with `schema=None` — which `get_from_clause` never produces, since it computes `self.schema or default_schema or ""`. It is therefore fixed here as a latent defect, not an active leak.

## Verification

Patched modules were run as an overlay (`PYTHONPATH`) inside a bugfixes2 pod against the real database and Databend — the running deployment was never modified:

| Scenario | Before | After |
|---|---|---|
| Valid clause | 52,145 rows | 52,145 rows (unchanged) |
| Apostrophe clause | 70,421 rows | `SupersetSecurityException`, no rows |
| Garbage clause | 70,421 rows | `SupersetSecurityException`, no rows |
| Trailing `AND` | 70,421 rows | `SupersetSecurityException`, no rows |
| Duplicate datasets | `MultipleResultsFound` | returns deterministically |

Unit tests added in `tests/unit_tests/models/test_rls_fail_closed.py`. Two existing tests mocked `.one_or_none()` and were updated for the new query shape.

## Exposure

**0** duplicate `(database_id, schema, table_name)` groups on both bugfixes2 and demo. The clause-parse bypass, however, is reachable today on any RLS clause sqlglot cannot parse.

## Upstream

Introduced by apache/superset#38683 ("apply RLS conservatively", `e2495119a3cd`) — upstream behaviour, not fork-specific. Worth upstreaming separately.

## Deployment ceiling

Draft on purpose. **Changing fail-open to fail-closed will surface dashboards that currently render only because RLS was silently skipped** — that discovery is the point of the change, and it is why this goes to `develop-6.1` and demo before any production consideration. Promotion to production is a separate human-coordinated step and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)