### PR TITLE
fix(security): resolve case-variant user duplicates in find_user (sc-23689)

### DIFF
--- a/plaid/security.py
+++ b/plaid/security.py
@@ -25,7 +25,6 @@ from plaid.auth_oidc import PlaidAuthOAuthView
 from superset.security import SupersetSecurityManager
 
 from sqlalchemy import func
-from sqlalchemy.orm.exc import MultipleResultsFound
 
 __author__ = "Garrett Bates"
 __copyright__ = "© Copyright 2018=2026, PlaidCloud, Inc"
@@ -135,36 +134,41 @@ class PlaidSecurityManager(SupersetSecurityManager):
         the email check case-insensitive
         """
         if username:
-            try:
-                if self.auth_username_ci:
-                    return (
-                        self.session.query(self.user_model)
-                        .filter(
-                            func.lower(self.user_model.username) == func.lower(username)
-                        )
-                        .one_or_none()
-                    )
-                else:
-                    return (
-                        self.session.query(self.user_model)
-                        .filter(self.user_model.username == username)
-                        .one_or_none()
-                    )
-            except MultipleResultsFound:
-                log.error("Multiple results found for user %s", username)
-                return None
-        elif email:
-            try:
-                return (
-                    self.session.query(self.user_model)
-                    .filter(
-                        func.lower(self.user_model.email) == func.lower(email)
-                    )
-                    .one_or_none()
+            if self.auth_username_ci:
+                query = self.session.query(self.user_model).filter(
+                    func.lower(self.user_model.username) == func.lower(username)
                 )
-            except MultipleResultsFound:
-                log.error("Multiple results found for user with email %s", email)
-                return None
+            else:
+                query = self.session.query(self.user_model).filter(
+                    self.user_model.username == username
+                )
+            return self._resolve_single_user(query, "username", username)
+        elif email:
+            query = self.session.query(self.user_model).filter(
+                func.lower(self.user_model.email) == func.lower(email)
+            )
+            return self._resolve_single_user(query, "email", email)
+
+    def _resolve_single_user(self, query, field, value):
+        """
+        Picks one user from a case-insensitive match.
+
+        ab_user.email and ab_user.username are case-sensitively unique, so rows
+        differing only in case legally coexist. Prefer an exact match, else the
+        oldest row, so a login never fails on the ambiguity.
+        """
+        users = query.order_by(self.user_model.id).all()
+        if len(users) > 1:
+            log.warning(
+                "Multiple users match %s %s case-insensitively; ids %s",
+                field,
+                value,
+                [user.id for user in users],
+            )
+        for user in users:
+            if getattr(user, field) == value:
+                return user
+        return users[0] if users else None
 
     def auth_user_oauth(self, userinfo):
         """

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -151,7 +151,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def _resolve_single_user(self, query, field, value):
         """
-        Picks one user from a case-insensitive match.
+        Picks one user when a lookup matches more than one row.
 
         ab_user.email and ab_user.username are case-sensitively unique, so rows
         differing only in case legally coexist. Prefer an exact match, else the

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -6,7 +6,8 @@ import logging
 import uuid
 import time
 import jwt
-from typing import Union, List, Optional, override
+from typing import Union, List, Optional
+from typing_extensions import override
 
 from urllib.parse import urljoin
 from flask import session

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -155,12 +155,13 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
         ab_user.email and ab_user.username are case-sensitively unique, so rows
         differing only in case legally coexist. Prefer an exact match, else the
-        oldest row, so a login never fails on the ambiguity.
+        lowest id, so a login never fails on the ambiguity.
         """
         users = query.order_by(self.user_model.id).all()
         if len(users) > 1:
             log.warning(
-                "Multiple users match %s %s case-insensitively; ids %s",
+                "Multiple users match %s %s; using the exact-case match if there is "
+                "one, else the lowest id. Matching ids: %s",
                 field,
                 value,
                 [user.id for user in users],

--- a/tests/unit_tests/plaid/__init__.py
+++ b/tests/unit_tests/plaid/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -25,16 +25,18 @@ from plaid.security import PlaidSecurityManager
 
 
 class FakeQuery:
-    """Stand-in for a SQLAlchemy Query over case-insensitively matched rows."""
+    """Stand-in for a SQLAlchemy Query, recording the criteria it is filtered on."""
 
-    def __init__(self, rows):
+    def __init__(self, rows, criteria):
         self.rows = rows
+        self.criteria = criteria
 
-    def filter(self, *args, **kwargs):
+    def filter(self, criterion):
+        self.criteria.append(criterion)
         return self
 
     def order_by(self, *args):
-        return FakeQuery(sorted(self.rows, key=lambda row: row.id))
+        return FakeQuery(sorted(self.rows, key=lambda row: row.id), self.criteria)
 
     def all(self):
         return list(self.rows)
@@ -57,13 +59,37 @@ class StubSecurityManager(PlaidSecurityManager):
 
 def make_manager(rows, auth_username_ci=True):
     manager = StubSecurityManager.__new__(StubSecurityManager)
-    manager.session = SimpleNamespace(query=lambda model: FakeQuery(rows))
+    manager.criteria = []
+    manager.session = SimpleNamespace(
+        query=lambda model: FakeQuery(rows, manager.criteria)
+    )
     manager.auth_username_ci = auth_username_ci
     return manager
 
 
 def user(user_id, name):
     return SimpleNamespace(id=user_id, username=name, email=name)
+
+
+def compiled(criterion):
+    return str(criterion.compile(compile_kwargs={"literal_binds": True}))
+
+
+@pytest.mark.parametrize(
+    ("field", "auth_username_ci", "expected"),
+    [
+        ("email", True, "lower(ab_user.email) = lower('Bob@Example.com')"),
+        ("email", False, "lower(ab_user.email) = lower('Bob@Example.com')"),
+        ("username", True, "lower(ab_user.username) = lower('Bob@Example.com')"),
+        ("username", False, "ab_user.username = 'Bob@Example.com'"),
+    ],
+)
+def test_find_user_filters_on_expected_column(field, auth_username_ci, expected):
+    manager = make_manager([], auth_username_ci=auth_username_ci)
+
+    manager.find_user(**{field: "Bob@Example.com"})
+
+    assert [compiled(criterion) for criterion in manager.criteria] == [expected]
 
 
 @pytest.mark.parametrize("field", ["email", "username"])

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from types import SimpleNamespace
+
+import pytest
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy.orm.exc import MultipleResultsFound
+
+from plaid.security import PlaidSecurityManager
+
+
+class FakeQuery:
+    """Stand-in for a SQLAlchemy Query over case-insensitively matched rows."""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args):
+        return FakeQuery(sorted(self.rows, key=lambda row: row.id))
+
+    def all(self):
+        return list(self.rows)
+
+    def one_or_none(self):
+        if len(self.rows) > 1:
+            raise MultipleResultsFound(
+                f"Multiple rows were found for one_or_none(): {len(self.rows)}"
+            )
+        return self.rows[0] if self.rows else None
+
+
+class StubSecurityManager(PlaidSecurityManager):
+    # Plain class attributes shadow the properties the real manager reads off
+    # the Flask app, so no app or appbuilder is needed.
+    user_model = User
+    auth_username_ci = True
+    session = None
+
+
+def make_manager(rows, auth_username_ci=True):
+    manager = StubSecurityManager.__new__(StubSecurityManager)
+    manager.session = SimpleNamespace(query=lambda model: FakeQuery(rows))
+    manager.auth_username_ci = auth_username_ci
+    return manager
+
+
+def user(user_id, name):
+    return SimpleNamespace(id=user_id, username=name, email=name)
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_prefers_exact_case_match(field):
+    rows = [user(7, "Bob@Example.com"), user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    found = manager.find_user(**{field: "Bob@Example.com"})
+
+    assert found is rows[0]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_falls_back_to_lowest_id(field):
+    rows = [user(7, "BOB@example.com"), user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    found = manager.find_user(**{field: "Bob@Example.com"})
+
+    assert found is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_single_match(field):
+    rows = [user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_no_match(field):
+    manager = make_manager([])
+
+    assert manager.find_user(**{field: "nobody@example.com"}) is None
+
+
+def test_find_user_case_sensitive_username_lookup():
+    rows = [user(3, "bob")]
+    manager = make_manager(rows, auth_username_ci=False)
+
+    assert manager.find_user(username="bob") is rows[0]
+
+
+def test_find_user_logs_duplicate_ids(caplog):
+    rows = [user(7, "BOB@example.com"), user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    manager.find_user(email="bob@example.com")
+
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert "[3, 7]" in warnings[0].getMessage()

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -119,6 +119,30 @@ def test_find_user_falls_back_to_lowest_id(field):
 
 
 @pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_lowest_id_wins_among_several_duplicates(field):
+    rows = [
+        user(9, "BOB@example.com"),
+        user(5, "bob@EXAMPLE.com"),
+        user(4, "bob@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_exact_match_beats_lower_ids(field):
+    rows = [
+        user(2, "BOB@example.com"),
+        user(4, "bob@example.com"),
+        user(9, "Bob@Example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
 def test_find_user_single_match(field):
     rows = [user(3, "bob@example.com")]
     manager = make_manager(rows)
@@ -138,6 +162,22 @@ def test_find_user_case_sensitive_username_lookup():
     manager = make_manager(rows, auth_username_ci=False)
 
     assert manager.find_user(username="bob") is rows[0]
+
+
+# The case-sensitive branch still resolves duplicates: on a database with a
+# case-insensitive collation an equality filter matches case variants anyway.
+def test_find_user_case_sensitive_username_prefers_exact_case_match():
+    rows = [user(7, "Bob"), user(3, "bob")]
+    manager = make_manager(rows, auth_username_ci=False)
+
+    assert manager.find_user(username="Bob") is rows[0]
+
+
+def test_find_user_case_sensitive_username_falls_back_to_lowest_id():
+    rows = [user(7, "BOB"), user(3, "bob")]
+    manager = make_manager(rows, auth_username_ci=False)
+
+    assert manager.find_user(username="Bob") is rows[1]
 
 
 def test_find_user_logs_duplicate_ids(caplog):

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -21,7 +21,13 @@ import pytest
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy.orm.exc import MultipleResultsFound
 
-from plaid.security import PlaidSecurityManager
+# plaid/ imports plaidcloud-rpc, which is in requirements/base.txt but not in the
+# development.txt that CI installs, so this module is only importable where the
+# runtime dependencies are present (the superset image). Skipping loudly beats a
+# collection error that aborts the whole unit-test run.
+pytest.importorskip("plaidcloud.rpc.connection.jsonrpc")
+
+from plaid.security import PlaidSecurityManager  # noqa: E402
 
 
 class FakeQuery:


### PR DESCRIPTION
Fixes sc-23689 — https://app.shortcut.com/plaidcloud/story/23689

### Problem
`ab_user.email` and `ab_user.username` carry **case-sensitive** unique constraints, so rows differing only in case legally coexist. The fork's case-**insensitive** `find_user` override (`3e203074c6`, "Band-aid fix find-user to be case-insensitive") hit `MultipleResultsFound` on those rows and returned `None`.

`auth_user_oauth` read `None` as "user does not exist" → called `add_user` → the INSERT violated `ab_user_email_key` → FAB 5.0.2 flashed "Invalid login" and redirected to `/login/`, which with a single OAuth provider bounces straight back to Keycloak. That loop — the Superset login page repainting ~1×/s — is the "intermittent screen" users reported.

Live at `pw-usesi` since the 6.1 upgrade (2026-07-13): 399 occurrences in 24h, three affected users.

### Fix
Resolve the ambiguity deterministically instead of failing: prefer the row matching the argument **exactly**, else the **lowest id**, and log the duplicate ids at WARNING so they surface in Loki. Applies to both the username and email lookups. Behaviour decided as D1(a) on the story.

Two incidental fixes were needed to get this tested at all:
- `plaid/security.py` imported `override` from `typing`, which is **Python 3.12+**, while the project targets `>=3.10` and CI's `current` leg runs 3.11. The runtime image is 3.12, so the module was simply never imported under CI — `plaid/` is absent from `scripts/change_detector.py`, so no Python CI job ever collected it. Now imported from `typing_extensions`.
- CI installs `requirements/development.txt`, which carries neither `plaidcloud-rpc` nor `databend_sqlalchemy` (only `base.txt` does), so importing `plaid.security` aborts the whole unit-test run at collection. The test now `importorskip`s and **skips loudly in CI**; it executes in the superset image, where the runtime deps exist.

### Verification
- `tests/unit_tests/plaid/test_security.py` — 20 tests, run in the superset image: `20 passed`.
- Fails-before / passes-after reproduced independently: `5 failed, 5 passed` on `develop-6.1` → green on this branch.
- Every assertion is mutation-tested. Dropping `func.lower`, swapping the username/email column, making the fallback pick the highest id, and deleting the exact-match loop each turn tests red; all reverted.
- 18-case differential harness vs `develop-6.1`: identical for one match, zero matches, no arguments, empty strings, and both arguments, under both `auth_username_ci` values. Only the duplicate-row path changes.
- Ruff at the pinned 0.9.7: `plaid/security.py` rule-code counts identical to base (the file is pre-existing red on `develop-6.1`); test files clean under `check` and `format --check`.
- **CI honesty:** the matrix is baseline-red on this repo (cypress, jest, playwright, pre-commit, License Check all fail on the last merged PR). `unit-tests` and `test-postgres*` currently fail on unrelated PRs too, on `ModuleNotFoundError: databend_sqlalchemy`. This branch is at baseline parity — `collected 5624 items / 2 skipped`, no collection error. `lint-check` is green. **The new tests do not execute in CI**; they run in the image.

### ⚠️ Rollout ordering — read before advancing any tenant tag
The `pw-usesi` Superset DB holds **18** case-variant duplicate pairs, not the 2 in the report. In each pair the hand-created row (mixed-case email, never logged in, owns nothing) holds branch/region roles the canonical OAuth row lacks, and USESI's 130+ RLS filters are `filter_type='Regular'` — which apply **only** to holders of their role, so a user without a branch role sees **every** branch. Fail-open.

Login resolves to the OAuth row (Keycloak sends the email lowercase — verified from the log lines that print the literal `find_user` argument, and from the code path having no normalisation anywhere), so **shipping this fix to USESI before those roles are merged onto the canonical rows would restore login while widening data access for 9 users.** Dedupe first; this fix is recurrence protection, not the unblock. Runbook and per-user role diff are on the story.

The same fail-open risk is **not limited to interactive login** — a clean-room review found `find_user` also backs:
- `superset/thumbnails/digest.py:66` — computes the RLS-scoped thumbnail **cache key**. A wrongly-scoped image is persisted and reused across viewers.
- `superset/commands/report/execute.py` and `superset/tasks/thumbnails.py` — scheduled report/alert screenshots, CSVs and dataframes resolve their executor the same way, and run on a schedule with nobody logging in.

Latent duplicates also exist at `pw-aah` (**33 pairs**) and `pw-hyster-yale` (1). Neither has been assessed for this exposure.

### Known limitation, deliberately not changed
`_resolve_single_user` does not consider `is_active`: with no exact-case match, an inactive lower-id row would win over an active higher-id one, turning the loud loop into a silent one. All 36 `pw-usesi` rows are active, so it is not reachable there; `pw-aah`/`pw-hyster-yale` are unaudited. Changing this would alter the owner-decided D1(a) rule, so it is flagged rather than done.

### Follow-ups (not in this PR)
- A case-insensitive unique index on `ab_user.email` — the real long-term guard, but alembic runs per tenant at deploy and index creation fails wherever duplicates exist; needs a fleet dedupe first.
- Get `plaid/` genuinely covered by CI: add `plaidcloud-rpc` to the dev requirements and `plaid/` to `scripts/change_detector.py`. Today a `plaid/`-only PR runs **no** Python CI — which is why a 3.12-only import sat undetected in a file on the login path.
- `superset/mcp_service/auth.py:171` looks users up by email case-sensitively with `.first()` and no ordering — same defect class, dead today (its only caller passes a username).
- `check-python-deps` began failing repo-wide this afternoon: `fastmcp` requires `authlib>=1.6.11` against a pinned `authlib==1.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
