### PR TITLE
fix(security): resolve case-variant user duplicates in find_user (sc-23689) [beta-6.1]

### DIFF
--- a/plaid/security.py
+++ b/plaid/security.py
@@ -6,7 +6,8 @@ import logging
 import uuid
 import time
 import jwt
-from typing import Union, List, Optional, override
+from typing import Union, List, Optional
+from typing_extensions import override
 
 from urllib.parse import urljoin
 from flask import session
@@ -25,7 +26,6 @@ from plaid.auth_oidc import PlaidAuthOAuthView
 from superset.security import SupersetSecurityManager
 
 from sqlalchemy import func
-from sqlalchemy.orm.exc import MultipleResultsFound
 
 __author__ = "Garrett Bates"
 __copyright__ = "© Copyright 2018=2026, PlaidCloud, Inc"
@@ -135,36 +135,42 @@ class PlaidSecurityManager(SupersetSecurityManager):
         the email check case-insensitive
         """
         if username:
-            try:
-                if self.auth_username_ci:
-                    return (
-                        self.session.query(self.user_model)
-                        .filter(
-                            func.lower(self.user_model.username) == func.lower(username)
-                        )
-                        .one_or_none()
-                    )
-                else:
-                    return (
-                        self.session.query(self.user_model)
-                        .filter(self.user_model.username == username)
-                        .one_or_none()
-                    )
-            except MultipleResultsFound:
-                log.error("Multiple results found for user %s", username)
-                return None
-        elif email:
-            try:
-                return (
-                    self.session.query(self.user_model)
-                    .filter(
-                        func.lower(self.user_model.email) == func.lower(email)
-                    )
-                    .one_or_none()
+            if self.auth_username_ci:
+                query = self.session.query(self.user_model).filter(
+                    func.lower(self.user_model.username) == func.lower(username)
                 )
-            except MultipleResultsFound:
-                log.error("Multiple results found for user with email %s", email)
-                return None
+            else:
+                query = self.session.query(self.user_model).filter(
+                    self.user_model.username == username
+                )
+            return self._resolve_single_user(query, "username", username)
+        elif email:
+            query = self.session.query(self.user_model).filter(
+                func.lower(self.user_model.email) == func.lower(email)
+            )
+            return self._resolve_single_user(query, "email", email)
+
+    def _resolve_single_user(self, query, field, value):
+        """
+        Picks one user when a lookup matches more than one row.
+
+        ab_user.email and ab_user.username are case-sensitively unique, so rows
+        differing only in case legally coexist. Prefer an exact match, else the
+        lowest id, so a login never fails on the ambiguity.
+        """
+        users = query.order_by(self.user_model.id).all()
+        if len(users) > 1:
+            log.warning(
+                "Multiple users match %s %s; using the exact-case match if there is "
+                "one, else the lowest id. Matching ids: %s",
+                field,
+                value,
+                [user.id for user in users],
+            )
+        for user in users:
+            if getattr(user, field) == value:
+                return user
+        return users[0] if users else None
 
     def auth_user_oauth(self, userinfo):
         """

--- a/tests/unit_tests/plaid/__init__.py
+++ b/tests/unit_tests/plaid/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -1,0 +1,190 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from types import SimpleNamespace
+
+import pytest
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy.orm.exc import MultipleResultsFound
+
+# plaid/ imports plaidcloud-rpc, which is in requirements/base.txt but not in the
+# development.txt that CI installs, so this module is only importable where the
+# runtime dependencies are present (the superset image). Skipping loudly beats a
+# collection error that aborts the whole unit-test run.
+pytest.importorskip("plaidcloud.rpc.connection.jsonrpc")
+
+from plaid.security import PlaidSecurityManager  # noqa: E402
+
+
+class FakeQuery:
+    """Stand-in for a SQLAlchemy Query, recording the criteria it is filtered on."""
+
+    def __init__(self, rows, criteria):
+        self.rows = rows
+        self.criteria = criteria
+
+    def filter(self, criterion):
+        self.criteria.append(criterion)
+        return self
+
+    def order_by(self, *args):
+        return FakeQuery(sorted(self.rows, key=lambda row: row.id), self.criteria)
+
+    def all(self):
+        return list(self.rows)
+
+    def one_or_none(self):
+        if len(self.rows) > 1:
+            raise MultipleResultsFound(
+                f"Multiple rows were found for one_or_none(): {len(self.rows)}"
+            )
+        return self.rows[0] if self.rows else None
+
+
+class StubSecurityManager(PlaidSecurityManager):
+    # Plain class attributes shadow the properties the real manager reads off
+    # the Flask app, so no app or appbuilder is needed.
+    user_model = User
+    auth_username_ci = True
+    session = None
+
+
+def make_manager(rows, auth_username_ci=True):
+    manager = StubSecurityManager.__new__(StubSecurityManager)
+    manager.criteria = []
+    manager.session = SimpleNamespace(
+        query=lambda model: FakeQuery(rows, manager.criteria)
+    )
+    manager.auth_username_ci = auth_username_ci
+    return manager
+
+
+def user(user_id, name):
+    return SimpleNamespace(id=user_id, username=name, email=name)
+
+
+def compiled(criterion):
+    return str(criterion.compile(compile_kwargs={"literal_binds": True}))
+
+
+@pytest.mark.parametrize(
+    ("field", "auth_username_ci", "expected"),
+    [
+        ("email", True, "lower(ab_user.email) = lower('Bob@Example.com')"),
+        ("email", False, "lower(ab_user.email) = lower('Bob@Example.com')"),
+        ("username", True, "lower(ab_user.username) = lower('Bob@Example.com')"),
+        ("username", False, "ab_user.username = 'Bob@Example.com'"),
+    ],
+)
+def test_find_user_filters_on_expected_column(field, auth_username_ci, expected):
+    manager = make_manager([], auth_username_ci=auth_username_ci)
+
+    manager.find_user(**{field: "Bob@Example.com"})
+
+    assert [compiled(criterion) for criterion in manager.criteria] == [expected]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_prefers_exact_case_match(field):
+    rows = [user(7, "Bob@Example.com"), user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    found = manager.find_user(**{field: "Bob@Example.com"})
+
+    assert found is rows[0]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_falls_back_to_lowest_id(field):
+    rows = [user(7, "BOB@example.com"), user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    found = manager.find_user(**{field: "Bob@Example.com"})
+
+    assert found is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_lowest_id_wins_among_several_duplicates(field):
+    rows = [
+        user(9, "BOB@example.com"),
+        user(5, "bob@EXAMPLE.com"),
+        user(4, "bob@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_exact_match_beats_lower_ids(field):
+    rows = [
+        user(2, "BOB@example.com"),
+        user(4, "bob@example.com"),
+        user(9, "Bob@Example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_single_match(field):
+    rows = [user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_no_match(field):
+    manager = make_manager([])
+
+    assert manager.find_user(**{field: "nobody@example.com"}) is None
+
+
+def test_find_user_case_sensitive_username_lookup():
+    rows = [user(3, "bob")]
+    manager = make_manager(rows, auth_username_ci=False)
+
+    assert manager.find_user(username="bob") is rows[0]
+
+
+# The case-sensitive branch still resolves duplicates: on a database with a
+# case-insensitive collation an equality filter matches case variants anyway.
+def test_find_user_case_sensitive_username_prefers_exact_case_match():
+    rows = [user(7, "Bob"), user(3, "bob")]
+    manager = make_manager(rows, auth_username_ci=False)
+
+    assert manager.find_user(username="Bob") is rows[0]
+
+
+def test_find_user_case_sensitive_username_falls_back_to_lowest_id():
+    rows = [user(7, "BOB"), user(3, "bob")]
+    manager = make_manager(rows, auth_username_ci=False)
+
+    assert manager.find_user(username="Bob") is rows[1]
+
+
+def test_find_user_logs_duplicate_ids(caplog):
+    rows = [user(7, "BOB@example.com"), user(3, "bob@example.com")]
+    manager = make_manager(rows)
+
+    manager.find_user(email="bob@example.com")
+
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert "[3, 7]" in warnings[0].getMessage()


### PR DESCRIPTION
Cherry-pick of #344 onto `beta-6.1`. Byte-identical to what merged on `develop-6.1` (`3a7bbba74bfd`) — verified with `git diff origin/develop-6.1 HEAD` over the touched paths (empty).

Fixes sc-23689 — https://app.shortcut.com/plaidcloud/story/23689

See #344 for the full root cause, evidence and verification. In short: `ab_user.email`/`username` are case-sensitively unique, so case-variant rows coexist; the fork's case-insensitive `find_user` returned `None` on them, OAuth read that as "new user", `add_user` violated `ab_user_email_key`, and FAB bounced the user back into an endless Superset login loop. This resolves the ambiguity deterministically (exact-case match, else lowest id, duplicate ids logged at WARNING).

### ✅ Previously held — hold now lifted

This PR was opened as a draft and held, because two beta-reachable tenants carried latent case-variant duplicates that had never been assessed for the data-exposure consequence seen at USESI (where 9 of 18 users hold a branch role only on the row this fix will *not* select, and `Regular` RLS filters apply only to role holders — so a user without one sees every branch).

A read-only audit of both tenants clears it:

| tenant | pairs | pairs losing a role | RLS filters | direction of loss | plain DELETE? | gates this PR? |
|---|---|---|---|---|---|---|
| `pw-aah` | 33 | 33 (66 grants: `Alpha`, `Plaid`) | **0** | fail-CLOSED (additive grants only) | yes | no |
| `pw-hyster-yale` | 1 | 0 (stale row holds no roles) | **0** | n/a | yes | no |

**Both tenants have zero rows in `row_level_security_filters`** (tables present at alembic `4b2a8c9d3e1f`; `rls_filter_roles`/`rls_filter_tables` empty). With no filters defined, the `Regular` fail-open mechanism cannot fire — a user missing a role cannot be widened by a filter that does not exist. The roles that would be lost at `pw-aah` are additive grants (`Alpha`, `Plaid`), so losing them narrows access rather than widening it.

Both tenants are armed but silent: they run the identical pre-fix `find_user` override with `AUTH_ROLES_SYNC_AT_LOGIN = False`, and Loki shows 0 hits over 14d against live streams (29,227 / 1,055 superset lines) — true negatives, because every affected user last logged in March–April 2026. They will loop on next login, so this fix helps them.

USESI is pinned to a `tenant-vX.Y.Z` tag and is not reached by a beta build; its dedupe is tracked on the story and is what actually unblocks the reported users.

### CI
Merged at baseline parity, not green — this repo's matrix is chronically red. `unit-tests`: `collected 5624 items / 2 skipped`, `50 failed, 1339 passed`, an identical failure set to unrelated PR #343 with **zero failures unique to this branch**. `lint-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
