### PR TITLE
fix(security): prefer active rows when resolving duplicate users (sc-23689)

### DIFF
--- a/plaid/security.py
+++ b/plaid/security.py
@@ -155,21 +155,24 @@ class PlaidSecurityManager(SupersetSecurityManager):
         Picks one user when a lookup matches more than one row.
 
         ab_user.email and ab_user.username are case-sensitively unique, so rows
-        differing only in case legally coexist. Prefer an exact match, else the
-        lowest id, so a login never fails on the ambiguity.
+        differing only in case legally coexist. Prefer an active row, then an
+        exact match, then the lowest id, so a login never fails on the ambiguity
+        and never lands on a deactivated duplicate. Deactivated rows are still
+        returned when they are all there is, leaving the active check to the
+        caller.
         """
         users = query.order_by(self.user_model.id).all()
         if len(users) > 1:
             log.warning(
-                "Multiple users match %s %s; using the exact-case match if there is "
-                "one, else the lowest id. Matching ids: %s",
+                "Multiple users match %s %s; preferring an active row, then the "
+                "exact-case match, then the lowest id. Matching ids: %s",
                 field,
                 value,
                 [user.id for user in users],
             )
-        for user in users:
-            if getattr(user, field) == value:
-                return user
+        users.sort(
+            key=lambda user: (not user.active, getattr(user, field) != value, user.id)
+        )
         return users[0] if users else None
 
     def auth_user_oauth(self, userinfo):

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -73,8 +73,8 @@ def make_manager(rows, auth_username_ci=True):
     return manager
 
 
-def user(user_id, name):
-    return SimpleNamespace(id=user_id, username=name, email=name)
+def user(user_id, name, active=True):
+    return SimpleNamespace(id=user_id, username=name, email=name, active=active)
 
 
 def compiled(criterion):
@@ -140,6 +140,70 @@ def test_find_user_exact_match_beats_lower_ids(field):
     manager = make_manager(rows)
 
     assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_skips_inactive_lowest_id(field):
+    rows = [
+        user(3, "bob@example.com", active=False),
+        user(7, "BOB@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_active_beats_inactive_exact_case_match(field):
+    rows = [
+        user(3, "Bob@Example.com", active=False),
+        user(7, "bob@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_exact_case_wins_among_active_rows(field):
+    rows = [
+        user(2, "bob@example.com", active=False),
+        user(4, "BOB@example.com"),
+        user(9, "Bob@Example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_returns_inactive_exact_case_match_when_all_inactive(field):
+    rows = [
+        user(3, "bob@example.com", active=False),
+        user(7, "Bob@Example.com", active=False),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_returns_inactive_lowest_id_when_all_inactive(field):
+    rows = [
+        user(7, "BOB@example.com", active=False),
+        user(3, "bob@example.com", active=False),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_single_inactive_match(field):
+    rows = [user(3, "bob@example.com", active=False)]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
 
 
 @pytest.mark.parametrize("field", ["email", "username"])

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -206,6 +206,44 @@ def test_find_user_single_inactive_match(field):
     assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
 
 
+# FakeQuery.order_by sorts by id like the real ORDER BY does, which would let a
+# resolver that only relied on a stable sort look correct. Feeding the resolver
+# rows in another order pins its own id tie-break.
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_resolve_single_user_lowest_id_wins_on_unordered_rows(field):
+    rows = [user(9, "BOB@example.com"), user(3, "bob@EXAMPLE.com")]
+    unordered = SimpleNamespace(
+        order_by=lambda *args: SimpleNamespace(all=lambda: list(rows))
+    )
+    manager = make_manager(rows)
+
+    found = manager._resolve_single_user(unordered, field, "Bob@Example.com")
+
+    assert found is rows[1]
+
+
+# active is Optional[bool] with a Python-side default, so a row written by raw
+# SQL can hold NULL. auth_user_oauth rejects those too, so de-preferring them
+# keeps this resolution in lockstep with the login gate.
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_prefers_active_over_null_active(field):
+    rows = [
+        user(3, "bob@example.com", active=None),
+        user(7, "BOB@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_single_null_active_match(field):
+    rows = [user(3, "bob@example.com", active=None)]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
+
+
 @pytest.mark.parametrize("field", ["email", "username"])
 def test_find_user_single_match(field):
     rows = [user(3, "bob@example.com")]


### PR DESCRIPTION
Follow-up to #344 / #345. Fixes sc-23689 — https://app.shortcut.com/plaidcloud/story/23689

### Problem
`_resolve_single_user` (added in #344) resolves case-variant duplicate `ab_user` rows as: exact-case match, else lowest `id`. It never consults `active`.

So if no row matches the login email exactly, the lowest-`id` row wins **even when deactivated**. `auth_user_oauth` returns `None` for an inactive user → FAB flashes "Invalid login" → redirects to `/login/` → with a single OAuth provider that bounces straight back to Keycloak. That is the same infinite login loop #344 fixed, but **silent**: no `MultipleResultsFound` error and no `ab_user_email_key` violation — the two log signals that made the original incident diagnosable at all.

Flagged independently by both review layers on #344, and left unimplemented there because it changes the owner-decided resolution rule. Now approved.

### Fix
Resolution order becomes active-first, with the previous ordering preserved within each group:
1. active row matching the argument exactly;
2. active row with the lowest `id`;
3. inactive rows only if no active row matches — same exact-case-then-lowest-id order.

`find_user` must never claim a user does not exist merely because their row is deactivated, so the inactive fallback is deliberate: dropping it would be a different regression.

The three-key precedence collapses to one sort:
```python
users.sort(key=lambda user: (not user.active, getattr(user, field) != value, user.id))
return users[0] if users else None
```

Reads the mapped `active` column rather than the `is_active` property: `active` is the source of truth, and `is_active` is a derived alias that synthetic guest-token users fake as always-True.

### Verification
- 38 tests (the 20 from #344 preserved), run in the superset image: `38 passed`.
- Every new assertion mutation-tested: dropping the active preference → 4 red; inactive fallback returning `None` → 8 red; dropping exactness → 9 red; dropping the `id` tie-break → 2 red; treating NULL `active` as active → 2 red. Reverted → green.
- The `id` tie-break and NULL-`active` handling are each pinned by a test that fails without them — the review caught that an earlier revision passed all 32 tests with the `id` key removed entirely.
- Ruff at the pinned 0.9.7: `plaid/security.py` rule-code counts identical to `develop-6.1`, code for code (the file is pre-existing red); test file clean under `check` and `format --check`.
- CI note: this repo's matrix is chronically red and the `plaid/` tests do not execute in CI (they `importorskip` — `requirements/development.txt` carries no `plaidcloud-rpc`). Judge this against baseline parity with other open PRs, not against green.

### Edge case, deliberate
`active` is `Optional[bool]` with a Python-side default, so a row inserted by raw SQL can hold NULL. `not None` is truthy, so such a row sorts as inactive — which matches `auth_user_oauth`'s own gate (`not user.is_active` also rejects NULL). Preference and rejection stay in lockstep; a NULL-`active` row loses to a genuinely active duplicate, which is the safe direction.


### ⚠️ Cost of this change — deactivation is a weaker lock while duplicates exist
Preferring `active` means deactivating **one** row of a duplicate pair no longer reliably blocks that person's login: if the case-variant twin is still active, they log in as the twin. Under the old rule an inactive exact-case match would at least sometimes be selected, and the login would fail.

Concretely, with `exact match inactive, non-exact row active`: the old rule returns the inactive row (login blocked), the new rule returns the active row (login succeeds).

This is the deliberate price of not turning an ambiguous lookup into a *silent* endless redirect. It is also not a regression against #344, which never guaranteed the deactivated row would be picked. Not reachable today — every duplicate pair found in production had **both** rows active, and all three affected tenants are now deduped. **Operationally: to revoke someone, deactivate every row matching their address, or delete the duplicate.**

### Review
Independently reviewed: **APPROVE**. Differential harness over both module versions confirms 12/12 non-duplicate scenarios return byte-identical winners (single active/inactive match, zero matches, empty-string value, both args, all-active, all-inactive); only the two intended cases diverge. Permutation-invariance verified — input order never changes the outcome.

### Context
All three tenants carrying case-variant duplicates (`pw-usesi`, `pw-aah`, `pw-hyster-yale`) have since been deduped, so there is no reachable path for this today. This is protection for the next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
