### PR TITLE
fix(security): prefer active rows when resolving duplicate users (sc-23689) [beta-6.1]

### DIFF
--- a/plaid/security.py
+++ b/plaid/security.py
@@ -155,21 +155,24 @@ class PlaidSecurityManager(SupersetSecurityManager):
         Picks one user when a lookup matches more than one row.
 
         ab_user.email and ab_user.username are case-sensitively unique, so rows
-        differing only in case legally coexist. Prefer an exact match, else the
-        lowest id, so a login never fails on the ambiguity.
+        differing only in case legally coexist. Prefer an active row, then an
+        exact match, then the lowest id, so a login never fails on the ambiguity
+        and never lands on a deactivated duplicate. Deactivated rows are still
+        returned when they are all there is, leaving the active check to the
+        caller.
         """
         users = query.order_by(self.user_model.id).all()
         if len(users) > 1:
             log.warning(
-                "Multiple users match %s %s; using the exact-case match if there is "
-                "one, else the lowest id. Matching ids: %s",
+                "Multiple users match %s %s; preferring an active row, then the "
+                "exact-case match, then the lowest id. Matching ids: %s",
                 field,
                 value,
                 [user.id for user in users],
             )
-        for user in users:
-            if getattr(user, field) == value:
-                return user
+        users.sort(
+            key=lambda user: (not user.active, getattr(user, field) != value, user.id)
+        )
         return users[0] if users else None
 
     def auth_user_oauth(self, userinfo):

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -73,8 +73,8 @@ def make_manager(rows, auth_username_ci=True):
     return manager
 
 
-def user(user_id, name):
-    return SimpleNamespace(id=user_id, username=name, email=name)
+def user(user_id, name, active=True):
+    return SimpleNamespace(id=user_id, username=name, email=name, active=active)
 
 
 def compiled(criterion):
@@ -140,6 +140,108 @@ def test_find_user_exact_match_beats_lower_ids(field):
     manager = make_manager(rows)
 
     assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_skips_inactive_lowest_id(field):
+    rows = [
+        user(3, "bob@example.com", active=False),
+        user(7, "BOB@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_active_beats_inactive_exact_case_match(field):
+    rows = [
+        user(3, "Bob@Example.com", active=False),
+        user(7, "bob@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_exact_case_wins_among_active_rows(field):
+    rows = [
+        user(2, "bob@example.com", active=False),
+        user(4, "BOB@example.com"),
+        user(9, "Bob@Example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[2]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_returns_inactive_exact_case_match_when_all_inactive(field):
+    rows = [
+        user(3, "bob@example.com", active=False),
+        user(7, "Bob@Example.com", active=False),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_returns_inactive_lowest_id_when_all_inactive(field):
+    rows = [
+        user(7, "BOB@example.com", active=False),
+        user(3, "bob@example.com", active=False),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_single_inactive_match(field):
+    rows = [user(3, "bob@example.com", active=False)]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
+
+
+# FakeQuery.order_by sorts by id like the real ORDER BY does, which would let a
+# resolver that only relied on a stable sort look correct. Feeding the resolver
+# rows in another order pins its own id tie-break.
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_resolve_single_user_lowest_id_wins_on_unordered_rows(field):
+    rows = [user(9, "BOB@example.com"), user(3, "bob@EXAMPLE.com")]
+    unordered = SimpleNamespace(
+        order_by=lambda *args: SimpleNamespace(all=lambda: list(rows))
+    )
+    manager = make_manager(rows)
+
+    found = manager._resolve_single_user(unordered, field, "Bob@Example.com")
+
+    assert found is rows[1]
+
+
+# active is Optional[bool] with a Python-side default, so a row written by raw
+# SQL can hold NULL. auth_user_oauth rejects those too, so de-preferring them
+# keeps this resolution in lockstep with the login gate.
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_prefers_active_over_null_active(field):
+    rows = [
+        user(3, "bob@example.com", active=None),
+        user(7, "BOB@example.com"),
+    ]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "Bob@Example.com"}) is rows[1]
+
+
+@pytest.mark.parametrize("field", ["email", "username"])
+def test_find_user_single_null_active_match(field):
+    rows = [user(3, "bob@example.com", active=None)]
+    manager = make_manager(rows)
+
+    assert manager.find_user(**{field: "BOB@EXAMPLE.COM"}) is rows[0]
 
 
 @pytest.mark.parametrize("field", ["email", "username"])


### PR DESCRIPTION
Cherry-pick of #346 onto `beta-6.1`. Byte-identical to what merged on `develop-6.1` (`459e5698dffc`) — verified with `git diff origin/develop-6.1 HEAD` over the touched paths (empty).

Fixes sc-23689 — https://app.shortcut.com/plaidcloud/story/23689

See #346 for the full rationale. In short: `_resolve_single_user` (from #344 / #345) picked the exact-case match, else the lowest `id`, never consulting `active`. An inactive row winning makes `auth_user_oauth` return `None`, which sends FAB into the same endless Keycloak redirect this story fixed — but **silently**, with neither of the two log signals that made the original incident diagnosable. Resolution is now active-first, with the previous ordering preserved inside each group, and an inactive fallback so `find_user` never claims a user doesn't exist merely because their row is deactivated.

### Verification
38 tests, `38 passed` in the superset image. Every assertion mutation-tested, including the two gaps an independent review caught (an earlier revision passed all 32 tests with the `id` tie-break removed entirely). Reviewed: **APPROVE** — a differential harness over both module versions confirms 12/12 non-duplicate scenarios return byte-identical winners; only the two intended cases diverge.

CI merged at baseline parity, not green — this repo's matrix is chronically red. `unit-tests`: `collected 5624 items / 2 skipped`, `50 failed, 1339 passed`, with the non-databend failure set **identical** to unrelated PR #343 (the 5 databend differences are the same tests, differing only in how an enum renders in the param id on 3.10 vs 3.11). `lint-check` green.

### ⚠️ Operational note
Preferring `active` means deactivating **one** row of a duplicate pair no longer reliably blocks that person's login — if the case-variant twin is still active, they log in as the twin. To revoke someone, deactivate every row matching their address, or delete the duplicate. Not reachable today: all three tenants that carried duplicates (`pw-usesi`, `pw-aah`, `pw-hyster-yale`) have been deduped, and every pair found in production had both rows active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
