### PR TITLE
fix(security): restrict UserRegistrationsRestAPI to Admin (sc-23689)

### DIFF
--- a/plaid/security.py
+++ b/plaid/security.py
@@ -57,7 +57,10 @@ class PlaidSecurityManager(SupersetSecurityManager):
     # guards the "User Registrations" ModelView menu but not the REST API's
     # view-menu, so Alpha/Gamma can POST a registration with any email and a
     # chosen registration_hash, then activate it into a real ab_user row via the
-    # unauthenticated /register/activation/<hash> route.
+    # unauthenticated /register/activation/<hash> route. Spelled as a literal
+    # rather than UserRegistrationsRestAPI.__name__ because importing that class
+    # here pulls superset.models.core in at config-load time, before init_app,
+    # which raises "App not initialized yet" out of encrypted_field_factory.
     ADMIN_ONLY_VIEW_MENUS = SupersetSecurityManager.ADMIN_ONLY_VIEW_MENUS | {
         "security",
         "UserRegistrationsRestAPI",

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -52,8 +52,15 @@ class PlaidSecurityManager(SupersetSecurityManager):
     # so ("read", "security") gets granted to Alpha/Gamma and those roles can
     # reach /users/, /roles/, /list_groups/ etc. directly even though the menu
     # is hidden. Adding "security" here makes the routes Admin-only too.
+    # UserRegistrationsRestAPI is a full ModelRestApi over RegisterUser, so FAB
+    # registers can_add/can_edit/can_delete alongside can_list/can_show. Upstream
+    # guards the "User Registrations" ModelView menu but not the REST API's
+    # view-menu, so Alpha/Gamma can POST a registration with any email and a
+    # chosen registration_hash, then activate it into a real ab_user row via the
+    # unauthenticated /register/activation/<hash> route.
     ADMIN_ONLY_VIEW_MENUS = SupersetSecurityManager.ADMIN_ONLY_VIEW_MENUS | {
         "security",
+        "UserRegistrationsRestAPI",
     }
 
     def __init__(self, appbuilder):

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -354,6 +354,10 @@ class UserRegistrationsRestAPI(BaseSupersetModelRestApi):
 
     resource_name = "security/user_registrations"
     datamodel = SQLAInterface(RegisterUser)
+    # Without this FAB also registers post/put, letting anyone holding the
+    # permission mint a registration and its activation hash. The frontend only
+    # lists, reads and deletes.
+    include_route_methods = {"get_list", "get", "delete", "info"}
     allow_browser_login = True
     list_columns = [
         "id",

--- a/tests/unit_tests/plaid/test_security.py
+++ b/tests/unit_tests/plaid/test_security.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound
 pytest.importorskip("plaidcloud.rpc.connection.jsonrpc")
 
 from plaid.security import PlaidSecurityManager  # noqa: E402
+from superset.security import SupersetSecurityManager  # noqa: E402
 
 
 class FakeQuery:
@@ -290,3 +291,33 @@ def test_find_user_logs_duplicate_ids(caplog):
 
     warnings = [record for record in caplog.records if record.levelname == "WARNING"]
     assert "[3, 7]" in warnings[0].getMessage()
+
+
+def pvm(permission_name, view_menu_name):
+    return SimpleNamespace(
+        permission=SimpleNamespace(name=permission_name),
+        view_menu=SimpleNamespace(name=view_menu_name),
+    )
+
+
+REGISTRATION_PERMISSIONS = ["can_list", "can_show", "can_add", "can_edit", "can_delete"]
+
+
+@pytest.mark.parametrize("permission_name", REGISTRATION_PERMISSIONS)
+def test_user_registrations_api_is_admin_only(permission_name):
+    manager = PlaidSecurityManager.__new__(PlaidSecurityManager)
+    permission_view = pvm(permission_name, "UserRegistrationsRestAPI")
+
+    assert manager._is_admin_only(permission_view)
+    assert not manager._is_alpha_pvm(permission_view)
+    assert not manager._is_gamma_pvm(permission_view)
+
+
+@pytest.mark.parametrize("permission_name", REGISTRATION_PERMISSIONS)
+def test_upstream_grants_user_registrations_api_to_alpha_and_gamma(permission_name):
+    """Pins the upstream gap the override exists to close."""
+    manager = SupersetSecurityManager.__new__(SupersetSecurityManager)
+    permission_view = pvm(permission_name, "UserRegistrationsRestAPI")
+
+    assert manager._is_alpha_pvm(permission_view)
+    assert manager._is_gamma_pvm(permission_view)


### PR DESCRIPTION
Follow-up to #344 / #346. Relates to sc-22467. Fixes sc-23689 — https://app.shortcut.com/plaidcloud/story/23689

### Problem
`UserRegistrationsRestAPI` (`superset/security/api.py:350`) is a FAB `ModelRestApi` over `RegisterUser` declaring only `list_columns` — **no `base_permissions`, no `include_route_methods`** — so FAB registers every verb including **POST**, despite a docstring calling it an Admin-only listing API.

Upstream's `ADMIN_ONLY_VIEW_MENUS` guards the sibling security APIs (`RoleRestAPI`, `User`, `Role`, `PermissionViewMenu`) and the legacy ModelView menu `"User Registrations"`, but **omits the view-menu `UserRegistrationsRestAPI`**. So `_is_alpha_pvm`/`_is_gamma_pvm` return True and **Alpha and Gamma receive `can_list/show/add/edit/delete`**.

That chains into user creation:
1. A Gamma POSTs a registration with an arbitrary email and a chosen `registration_hash` (`add_columns` is auto-derived to every editable column; the REST path skips the uniqueness validation the registration *form* performs).
2. `GET /register/activation/<hash>` (`superset/views/auth.py:58-83`) has **no auth decorator at all** and calls `add_user()`, writing a real `ab_user` row.
3. The hash needn't be guessed — `list_columns` exposes `registration_hash` and Gamma also holds `can_list`.

Not privilege escalation (the new row lands in the empty `Public` role), but it is exactly the **sc-23689 lockout primitive**: mint a case-variant `ab_user` row for a colleague's address and put them in the endless Superset login loop this story is about.

**Confirmed live, read-only, across all 28 Superset tenants: Alpha and Gamma hold all five permissions at every one, with zero variance** — including USESI, Saputo, BCBSNC, PwC, AAH. `ab_register_user` is empty fleet-wide, so there's no evidence the path has been exercised (though a completed activation consumes the row, so that isn't proof).

### Fix
Two layers:
1. `plaid/security.py` — add `UserRegistrationsRestAPI` to the fork's existing `ADMIN_ONLY_VIEW_MENUS` override, which already carries `"security"` for this same class of upstream omission.
2. `superset/security/api.py` — declare `include_route_methods = {"get_list", "get", "delete", "info"}` so POST and PUT are never registered at all. Thirteen sibling APIs in this codebase already do this; `UserRegistrationsRestAPI` was the only outlier. This stops the `can_add`/`can_edit` permission rows from existing, rather than relying solely on role-sync filtering.

`info` is included deliberately: `useListViewResource` unconditionally fetches `/_info` (`superset-frontend/src/views/CRUD/hooks.ts:118`) and would raise a visible error toast on every page load without it. It maps to `list`, adding no write surface.

### Verification
- 48 tests pass; the 5 new classification tests fail against `develop-6.1` and pass here — reproduced independently by a clean-room reviewer, not just by the author.
- Mechanism verified in FAB 5.0.2 in the runtime image: `class_permission_name` defaults to `self.__class__.__name__` (`api/__init__.py:510-511`), so `"UserRegistrationsRestAPI"` is genuinely the registered view-menu name — **this is not a no-op guard**.
- **No caller breaks.** Repo-wide sweep across `.py/.ts/.tsx/.js/.yaml/.sh` and the tenant-infrastructure repo found only GET (`useListViewResource`) and DELETE in the frontend. No POST, no PUT, no CLI path.
- Ruff at the pinned 0.9.7: `superset/security/api.py` clean both sides; `plaid/security.py` rule-code counts identical to base (pre-existing red).

### Remediation is automatic
`set_role` assigns `role.permissions = role_pvms` wholesale (`superset/security/manager.py:1461-1478`), and tenants run `superset init` as a Helm `post-install,post-upgrade` hook on every ArgoCD sync. Admin/Alpha/Gamma/sql_lab/Public re-sync themselves on the next deploy.

`sync_role_definitions` does **not** touch custom roles — but the live audit checked every role at all 28 tenants and found **none holds this permission**, including `Gamma USESI` (272 users) and the legacy `Plaid` role. **No tenant needs manual remediation.** The only residual is a role cloned from Gamma between now and this landing.

Pre-existing `can_add`/`can_edit` rows in `ab_permission_view` are not pruned by `superset init` (that's `superset security-cleanup`), but after this change they are detached from every role and have no route left to exercise — inert, not a gap.

### Deliberately NOT in this PR (separate, larger story)
- The unauthenticated `GET /register/activation/<hash>` route.
- `registration_hash` exposed in `list_columns` to Admins.
- Disabling self-registration (`AUTH_USER_REGISTRATION = True` at all 28 tenants is what registers the activation view at all — a fleet-wide kill-switch available without any release, at the cost of OAuth auto-provisioning).

### CI
This repo's matrix is chronically red; judge against baseline parity with other open PRs, not against green. The `plaid/` tests do not execute in CI (they `importorskip` — `requirements/development.txt` carries no `plaidcloud-rpc`); they run in the superset image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
