### PR TITLE
fix(ci): run change detector on schedule and dispatch events

### DIFF
--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -20,7 +20,7 @@ import json
 import os
 import re
 import subprocess
-from typing import List
+from typing import List, Optional
 from urllib.request import Request, urlopen
 
 # Define patterns for each group of files you're interested in
@@ -111,7 +111,8 @@ def main(event_type: str, sha: str, repo: str) -> None:
     """Main function to check for file changes based on event context."""
     print("SHA:", sha)
     print("EVENT_TYPE", event_type)
-    files = []
+    # `None` means "no diff to compute" and marks every group as changed.
+    files: Optional[List[str]] = []
     if event_type == "pull_request":
         pr_number = os.getenv("GITHUB_REF", "").split("/")[-2]
         if is_int(pr_number):
@@ -124,11 +125,14 @@ def main(event_type: str, sha: str, repo: str) -> None:
         print("Files touched since previous commit:")
         print_files(files)
 
-    elif event_type == "workflow_dispatch":
-        print("Workflow dispatched, assuming all changed")
+    elif event_type in {"schedule", "workflow_dispatch"}:
+        # There is no diff to compute for these: a scheduled scan must never be
+        # skipped, and a manual dispatch is an explicit request to run.
+        print(f"Event '{event_type}', assuming all changed")
+        files = None
 
     else:
-        raise ValueError("Unsupported event type")
+        raise ValueError(f"Unsupported event type: {event_type}")
 
     changes_detected = {}
     for group, regex_patterns in PATTERNS.items():
@@ -144,7 +148,7 @@ def main(event_type: str, sha: str, repo: str) -> None:
             # NOTE: as noted above, we assume that if 100 files are touched, we should
             # trigger all checks. This is a workaround for the GitHub API limit of 100
             # files. Using >= 99 because off-by-one errors are not uncommon
-            if changed or len(files) >= 99:
+            if changed or (files is not None and len(files) >= 99):
                 print(f"{check}=true", file=f)
                 print(f"Triggering group: {check}")
 


### PR DESCRIPTION
### SUMMARY

The CodeQL workflow (`.github/workflows/codeql-analysis.yml`) runs on a `schedule` trigger (`cron: "0 4 * * *"`), but `scripts/change_detector.py` only handled `pull_request`, `push` and `workflow_dispatch`. A scheduled run fell through to `raise ValueError("Unsupported event type")` and failed the job at the `Check for file changes` step — before `Initialize CodeQL`.

The visible symptom is a daily red run. The actual impact is that **the scheduled security scan never ran**: every nightly execution died in ~20s.

While fixing that, a second, quieter bug surfaced in the same branch. `workflow_dispatch` printed `"Workflow dispatched, assuming all changed"` but left `files` as an empty list. Since the test is `files is None or detect_changes(files, ...)`, an empty list yields `False` for every group, and the analyze step is gated on `if: steps.check.outputs.python || steps.check.outputs.frontend`. So a manual dispatch didn't scan either — it just didn't fail, which made it harder to notice.

Both events now set `files = None`, which is the signal the code already uses for _"there is no diff to compute, treat every group as changed"_ — the behaviour the original comment claimed but didn't implement.

Also included:
- `len(files)` is guarded against `None` (safe today via short-circuit, but no longer dependent on that).
- The error message now names the offending event, which would have made this a one-look diagnosis.

`push` and `pull_request` paths are untouched.

### TESTING INSTRUCTIONS

Run the detector directly for each event and inspect what it writes to `GITHUB_OUTPUT`:

```bash
for EV in schedule workflow_dispatch bogus_event; do
  echo "--- $EV ---"
  GITHUB_OUTPUT=/tmp/out_$EV.txt python scripts/change_detector.py \
    --event-type $EV --sha deadbeef --repo apache/superset
  cat /tmp/out_$EV.txt
done
```

| Event | Before | After |
|---|---|---|
| `schedule` | `ValueError`, job fails, scan never runs | all 5 groups `=true` |
| `workflow_dispatch` | passes, but 0 groups → analyze skipped | all 5 groups `=true` |
| unknown event | `ValueError` with no context | `ValueError: Unsupported event type: bogus_event` |

Then confirm the next scheduled CodeQL run reaches `Initialize CodeQL` instead of failing at `Check for file changes`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Note: this bug is not a fork divergence — `scripts/change_detector.py` is unmodified from upstream here, so `apache/superset` is likely affected the same way. May be worth an upstream PR as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)