### PR TITLE
fix(datasets): skip unresolvable metrics instead of failing the dashboard

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -495,7 +495,22 @@ class BaseDatasource(
             # pull out all required metrics from the form_data
             for metric_param in METRIC_FORM_DATA_PARAMS:
                 for metric in utils.as_list(form_data.get(metric_param) or []):
-                    metric_names.add(utils.get_metric_name(metric, self.verbose_map))
+                    # a chart may carry a pseudo-metric that isn't resolvable to a
+                    # name — e.g. a layout-only row heading with no expressionType.
+                    # Skip it instead of failing the whole dashboard's datasets.
+                    try:
+                        metric_names.add(
+                            utils.get_metric_name(metric, self.verbose_map)
+                        )
+                    except ValueError:
+                        logger.warning(
+                            "Skipping unresolvable metric in '%s' on chart "
+                            "'%s' (id=%s)",
+                            metric_param,
+                            slc.slice_name,
+                            slc.id,
+                        )
+                        continue
                     if utils.is_adhoc_metric(metric):
                         column_ = metric.get("column") or {}
                         if column_name := column_.get("column_name"):

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -948,6 +948,56 @@ def test_data_for_slices_handles_missing_datasource(mocker: MockerFixture) -> No
     assert "verbose_map" in result
 
 
+def test_data_for_slices_handles_unresolvable_metric(mocker: MockerFixture) -> None:
+    """
+    Test that data_for_slices skips a pseudo-metric that cannot be resolved to a
+    name instead of failing the whole dashboard.
+
+    Layout-only row headings are persisted in form_data as metric-shaped dicts
+    with no `expressionType` and an empty `label`. get_metric_name() raises
+    ValueError on those, which previously propagated and made
+    /api/v1/dashboard/<id>/datasets fail, leaving native filters with no
+    datasources.
+    """
+    database = mocker.MagicMock()
+    database.id = 1
+
+    table = SqlaTable(
+        table_name="test_table",
+        database=database,
+        columns=[],
+        metrics=[],
+    )
+
+    row_heading = {
+        "aggregate": None,
+        "column": {"column_name": "__heading__"},
+        "emptyRowHeading": True,
+        "emptyRowHeadingText": "SALES",
+        "hasCustomLabel": False,
+        "isEmpty": False,
+        "label": "",
+        "optionName": "metric_ruu5z64aum_xnww8skbcu",
+        "sqlExpression": None,
+    }
+
+    mock_slice = mocker.MagicMock()
+    mock_slice.id = 1
+    mock_slice.slice_name = "EBITx by Segment"
+    mock_slice.form_data = {"metrics": [row_heading, "count"]}
+    mock_slice.get_query_context.return_value = None
+
+    mocker.patch.object(SqlaTable, "columns", [])
+    mocker.patch.object(SqlaTable, "metrics", [])
+
+    # Must not raise: the unresolvable heading is skipped, the real metric is kept
+    result = table.data_for_slices([mock_slice])
+
+    assert "columns" in result
+    assert "metrics" in result
+    assert "verbose_map" in result
+
+
 def test_owners_data_includes_email(mocker: MockerFixture) -> None:
     """Test that the owners_data property includes the email field."""
     database = mocker.MagicMock()


### PR DESCRIPTION
### SUMMARY

`GET /api/v1/dashboard/<id>/datasets` can return **422** and take down native filters for a whole dashboard because of a single malformed pseudo-metric on a single chart.

`BaseDatasource.data_for_slices()` calls `utils.get_metric_name()` on every entry of every `METRIC_FORM_DATA_PARAMS` list. `get_metric_name()` raises `ValueError("Invalid metric object: ...")` for a dict it can't resolve to a name (`is_adhoc_metric()` requires `expressionType`; a dict without it, that isn't a string, falls through to the raise). That exception propagates out of `datasets_trimmed_for_slices()`, the endpoint wraps it as `DatasetValidationError`, and the frontend surfaces:

> Error loading chart datasources. Filters may not work correctly.

The failure mode is unpleasant to diagnose because the charts still render fine — they load through their own endpoints — so it reads as a filter bug rather than a metadata one. Meanwhile `setDatasources()` is never dispatched and the dashboard's native filters have nothing to work with.

**Where the malformed metrics come from:** layout-only row headings persisted into `form_data.metrics` with no `expressionType` and an empty `label`. Concretely:

```json
{"aggregate": null, "column": {"column_name": "__heading__"},
 "emptyRowHeading": true, "emptyRowHeadingText": "SALES",
 "hasCustomLabel": false, "isEmpty": false, "label": "",
 "optionName": "metric_ruu5z64aum_xnww8skbcu", "sqlExpression": null}
```

The `AdhocMetric` class always sets `expressionType` and derives a label, so metrics created through it are fine — but data already persisted this way is not, and cleaning it chart-by-chart doesn't protect against the next one.

This skips the unresolvable entry and logs a warning, so one bad heading costs you that heading rather than the entire dashboard's datasources. It mirrors the `DatasetNotFoundError`/`DatasourceNotFound` guard that already exists ~20 lines below in the same loop, for the same class of "legacy data shouldn't 500 the endpoint" reason.

Valid metrics on the same chart are still collected normally.

### TESTING INSTRUCTIONS

New unit test reproduces the exact shape:

```bash
pytest tests/unit_tests/connectors/sqla/models_test.py -k data_for_slices
```

`test_data_for_slices_handles_unresolvable_metric` passes a chart whose `form_data.metrics` holds the row-heading dict above alongside a normal `"count"` metric, and asserts `data_for_slices()` returns a valid payload instead of raising.

Manually: put a chart carrying such a metric on a dashboard and hit `/api/v1/dashboard/<id>/datasets`. Before: 422 and the toast above. After: 200, filters populate, and a warning is logged naming the chart.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)