### PR TITLE
fix(security): render permalink PDF as caller, not hardcoded admin (sc-24049)

### DIFF
--- a/superset/dashboards/permalink/api.py
+++ b/superset/dashboards/permalink/api.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from io import BytesIO
 from urllib import parse
 
-from flask import g, request, Response, url_for, send_file
+from flask import g, request, Response, send_file, url_for
 from flask_appbuilder.api import expose, protect, safe
 from marshmallow import ValidationError
 
@@ -34,9 +34,9 @@ from superset.dashboards.permalink.exceptions import DashboardPermalinkInvalidSt
 from superset.dashboards.permalink.schemas import DashboardPermalinkStateSchema
 from superset.extensions import event_logger
 from superset.key_value.exceptions import KeyValueAccessDeniedError
-from superset.views.base_api import BaseSupersetApi, requires_json
 from superset.utils.screenshots import DashboardScreenshot
 from superset.utils.urls import headless_url
+from superset.views.base_api import BaseSupersetApi, requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +276,8 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
             dashboard_id, state = value["dashboardId"], value.get("state", {})
             dashboard_url = headless_url(
                 url_for(
-                    "Superset.dashboard", dashboard_id_or_slug=dashboard_id,
+                    "Superset.dashboard",
+                    dashboard_id_or_slug=dashboard_id,
                     permalink_key=key,
                     _external=False,
                 ),
@@ -314,4 +315,3 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except DashboardNotFoundError as ex:
             return self.response(404, message=str(ex))
-

--- a/superset/dashboards/permalink/api.py
+++ b/superset/dashboards/permalink/api.py
@@ -294,6 +294,8 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
 
             screenshot = DashboardScreenshot(dashboard_url, None)
             pdf = screenshot.get_pdf(user=g.user)
+            if pdf is None:
+                return self.response(500, message="Failed to generate dashboard PDF")
             buf = BytesIO(pdf)
             buf.seek(0)
 

--- a/superset/dashboards/permalink/api.py
+++ b/superset/dashboards/permalink/api.py
@@ -19,11 +19,10 @@ from datetime import datetime
 from io import BytesIO
 from urllib import parse
 
-from flask import request, Response, url_for, send_file
+from flask import g, request, Response, url_for, send_file
 from flask_appbuilder.api import expose, protect, safe
 from marshmallow import ValidationError
 
-from superset import security_manager
 from superset.commands.dashboard.exceptions import (
     DashboardAccessDeniedError,
     DashboardNotFoundError,
@@ -36,7 +35,6 @@ from superset.dashboards.permalink.schemas import DashboardPermalinkStateSchema
 from superset.extensions import event_logger
 from superset.key_value.exceptions import KeyValueAccessDeniedError
 from superset.views.base_api import BaseSupersetApi, requires_json
-from superset.utils.core import override_user
 from superset.utils.screenshots import DashboardScreenshot
 from superset.utils.urls import headless_url
 
@@ -293,12 +291,10 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
 
             logger.info("Create dashboard PDF for : %s", dashboard_url)
 
-            user = security_manager.find_user("admin")
-            with override_user(user):
-                screenshot = DashboardScreenshot(dashboard_url, None)
-                pdf = screenshot.get_pdf(user=user)
-                buf = BytesIO(pdf)
-                buf.seek(0)
+            screenshot = DashboardScreenshot(dashboard_url, None)
+            pdf = screenshot.get_pdf(user=g.user)
+            buf = BytesIO(pdf)
+            buf.seek(0)
 
             timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
             root = f"dashboard_pdf_{timestamp}"

--- a/tests/unit_tests/dashboards/permalink/__init__.py
+++ b/tests/unit_tests/dashboards/permalink/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/dashboards/permalink/api_test.py
+++ b/tests/unit_tests/dashboards/permalink/api_test.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=unused-argument, import-outside-toplevel
+
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+
+def test_get_pdf_renders_as_caller(
+    mocker: MockerFixture,
+    app: Any,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    The permalink PDF endpoint must render as the calling user, never as a
+    hardcoded ``admin`` — otherwise every chart resolves RLS and
+    datasource_access as admin (sc-24049).
+    """
+    from superset import security_manager
+    from superset.dashboards.permalink import api as permalink_api
+
+    caller = mocker.MagicMock(name="caller")
+    mocker.patch.object(permalink_api, "g", mocker.MagicMock(user=caller), create=True)
+    find_user = mocker.patch.object(security_manager, "find_user")
+
+    command = mocker.patch.object(permalink_api, "GetDashboardPermalinkCommand")
+    command.return_value.run.return_value = {"dashboardId": 1, "state": {}}
+
+    screenshot = mocker.patch.object(permalink_api, "DashboardScreenshot")
+    screenshot.return_value.get_pdf.return_value = b"%PDF-1.4 fake"
+
+    response = client.get("/api/v1/dashboard/permalink/abc/pdf")
+
+    assert response.status_code == 200
+    screenshot.return_value.get_pdf.assert_called_once_with(user=caller)
+    find_user.assert_not_called()


### PR DESCRIPTION
## Symptom
`GET /api/v1/dashboard/permalink/<key>/pdf` rendered the dashboard in a headless browser authenticated as a hardcoded `admin` user, not as the caller. Every chart on the dashboard was then fetched over HTTP under an **admin session cookie**, so all RLS predicates and `datasource_access` checks resolved against admin's grants. Any authenticated user who could open a dashboard and hold a permalink key received admin-rendered output — a full RLS and permission bypass. The route's only gate is dashboard *read*.

## Root cause
`superset/dashboards/permalink/api.py` (the `get_pdf` handler):

```python
user = security_manager.find_user("admin")
with override_user(user):
    screenshot = DashboardScreenshot(dashboard_url, None)
    pdf = screenshot.get_pdf(user=user)
    ...
```

`find_user("admin")` → `override_user(user)` → `get_pdf(user=user)` reaches `machine_auth.login_user(user)`, minting the admin cookie for the headless browser. Fork-only code; upstream has no permalink PDF route.

## Change
- Render as `g.user` (the authenticated caller, guaranteed by `@protect()`); drop the `override_user` wrapper.
- Remove the now-unused `security_manager` and `override_user` imports.
- Guard the `screenshot.get_pdf()` → `None` case (typed `bytes | None`; a headless render can fail) with a 500 instead of crashing `BytesIO(None)` into `@safe`'s generic handler.
- Sort/format the imports in the touched block (ruff) — see CI note below.
- New unit test `tests/unit_tests/dashboards/permalink/api_test.py`: asserts the PDF pipeline is called with the caller and that `security_manager.find_user` is never invoked. Both assertions go RED if the handler reverts to admin-render.

Why this is a real fix, not cosmetic: `get_pdf(user=g.user)` → `driver.get_pdf(url, el, user)` → `auth(user)` → `machine_auth.login_user(user)` injects **that user's** session cookie into the headless browser, so every chart resolves RLS + `datasource_access` as the caller. An unauthorized caller is already rejected with 403 before rendering (`GetDashboardPermalinkCommand` runs the dashboard access check first); a caller lacking `datasource_access` to a chart sees that chart render as an error, not data.

## Verification
Local Docker runner (`python:3.11`, full `requirements/development.txt` + editable install): the new test is **red before / green after**.

CI (this fork's `unit-tests` rollup is now trustworthy — sc-23907 fixed on develop-6.1): **`unit-tests`, `pre-commit`, `lint-check`, `cypress-matrix`, `playwright-tests`, `test-postgres-hive`/`-presto`, `test-load-examples` all pass.**

⚠️ CI pre-commit is **diff-scoped** (`pre-commit run --from-ref base --to-ref HEAD`), so touching `api.py` pulls its pre-existing ruff `I001` and one mypy `arg-type` error into the gate even though they are identical on `develop-6.1` HEAD. Both are fixed here (import sort; `None` guard) — that is what the two follow-up commits do.

The remaining red checks — `License Check`, `check-python-deps`, `python-dependency-liccheck`, `test-mysql`, `test-postgres`, `test-sqlite` — are **red fleet-wide and are not merge gates**: they are red identically on already-merged PRs on this branch (e.g. #364). `develop-6.1` has no required checks.

## Release path (human steps — not done here)
Cherry-pick to `beta-6.1`, build the image, roll the tenant pins. All manual.

## Out of scope (follow-ups, not fixed here)
1. The PlaidCloud-side `pdf_to_document` path (in the `plaid` repo) proxies to this endpoint as the `admin` service account and checks only document-account access, not dashboard ACL — a workspace user can still obtain an admin-rendered PDF of any dashboard. Separate repo, separate issue.
2. `BaseScreenshot.get_cache_key` (`superset/utils/screenshots.py`) omits the user, so the **thumbnail/screenshot** cache is user-independent. This PDF endpoint does not touch that cache (it renders live, `digest=None`), so it is unaffected — but the user-independent key on the screenshot path predates this PR and is worth its own ticket.

https://app.shortcut.com/plaidcloud/story/24049

🤖 Generated with [Claude Code](https://claude.com/claude-code)
