### PR TITLE
fix(security): protect plaid_rls_* roles and rules from non-automation writes

### DIFF
--- a/plaid/rls_guard.py
+++ b/plaid/rls_guard.py
@@ -1,0 +1,232 @@
+# coding=utf-8
+"""sc-23432 Part 4 -- the fork-side write guard for PlaidCloud-generated RLS.
+
+`git grep -e plaid_rls origin/develop-6.1` returned ZERO before this file: there
+was no ownership or prefix protection on `plaid_rls_*` roles or the RLS rules
+PlaidCloud's role/rule reconciler generates. A Keycloak `is_admin` claim reaches
+Superset Admin (`plaid/security.py`'s `oauth_user_info`, mapped via the deployed
+tenant's `AUTH_ROLES_MAPPING`), and Admin holds `Role.can_update_role_users` /
+`can_edit` / `can_delete` on roles and full CRUD on `RowLevelSecurityFilter` --
+so, unguarded, any customer workspace admin could add themselves (or anyone) to
+a `plaid_rls_*` role -- permanent, since nothing else reconciles a roster edit
+away -- or delete a Base guard rule, turning off row-level security for that
+dataset until PlaidCloud's next reconcile pass.
+
+## What this protects, and what it deliberately does not
+
+Protected: create / rename / roster-write / delete of any Superset Role or
+RowLevelSecurityFilter whose ``name`` starts with the reserved stem
+``plaid_rls``. That one stem covers both literal forms the plan's naming
+scheme produces (sc-23432 non-negotiable 5): roles are always
+``plaid_rls_<keycloak-group-id>``; rules are ``plaid_rls_<project-id>_<hash>``
+(Regular) or ``plaid_rlsguard_<project-id>_<hash>`` (Base guard). Renaming a
+role or rule INTO the stem is blocked symmetrically -- a workspace admin
+cannot pre-empt or impersonate a name the reconciler expects to own next.
+
+NOT protected here, disclosed rather than silently assumed to be covered:
+dataset identity. ``DatasetPutSchema`` lets a dataset owner rewrite
+``table_name`` / ``schema`` / ``catalog`` / ``sql`` behind
+``raise_for_ownership``, which any Admin passes -- a second way to point a
+generated rule's binding at different data without touching the rule or role
+this guard watches at all. Out of scope for Part 4; see sc-23432 (referenced by
+description only -- do not cite it in commits/branches/PRs in THIS repo).
+
+## Who may write a protected resource
+
+Exactly one Superset identity: whoever ``PLAID_RLS_AUTOMATION_USERNAME`` names
+(default ``admin``, matching the username plaid's own service calls
+authenticate to Superset as -- see ``add_superset_user`` /
+``superset_get_token`` in the plaid repo, provider ``db``, never Keycloak
+OAuth). Every Keycloak-mapped human -- including one holding the ``Admin``
+role via an ``is_admin`` claim -- is a DIFFERENT ``ab_user`` row, self-
+registered on first login by ``PlaidSecurityManager.auth_user_oauth``, and is
+refused here regardless of role. Unconfigured (``None`` / empty string) fails
+CLOSED: nobody may write a protected resource, not "anyone may."
+
+## Why this lives in ``plaid/``, and how it attaches
+
+Two different attachment points, because the two resource kinds are wired into
+Superset differently:
+
+* Roles: ``SecurityManager.role_api`` is already an override point --
+  ``SupersetSecurityManager`` sets it to ``SupersetRoleApi`` (see
+  ``superset/security/manager.py``) so that FAB's own
+  ``register_views()`` -> ``self.appbuilder.add_api(self.role_api)`` picks up
+  the subclass. ``PlaidRoleApi`` here extends that same subclass; wiring it in
+  is one line on ``PlaidSecurityManager`` (``role_api = PlaidRoleApi``).
+* RLS rules: ``RLSRestApi`` (``superset/row_level_security/api.py``) has no
+  equivalent override attribute -- Superset registers the class directly. Its
+  ``post`` / ``put`` / ``delete`` / ``bulk_delete`` are monkeypatched in place
+  by ``install()`` below, called from ``PlaidSecurityManager.__init__`` --
+  which Superset's app factory runs during app construction, well before the
+  app accepts its first request, and after ``super().__init__`` has already
+  pulled in Superset's own security wiring. Patching the class attribute is
+  sufficient: Python resolves ``self.post(...)`` from the class's current
+  ``__dict__`` at CALL time, not at route-registration time, so ordering
+  relative to ``add_api(RLSRestApi)`` does not matter.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+
+from flask import current_app, g
+
+logger = logging.getLogger(__name__)
+
+# Roles only ever use this exact form (trailing underscore -- a role is never
+# a guard). Rules use this stem with either `_` (Regular) or `guard_`
+# (Base guard) after it -- `is_protected_rule_name` checks the shorter,
+# underscore-less stem so both survive one check.
+PLAID_RLS_ROLE_PREFIX = 'plaid_rls_'
+PLAID_RLS_NAME_STEM = 'plaid_rls'
+
+DENIAL_MESSAGE = (
+    "{name!r} is a PlaidCloud-generated row-access resource. It can only be "
+    "written by PlaidCloud's own automation."
+)
+
+
+def is_protected_role_name(name) -> bool:
+    return bool(name) and name.startswith(PLAID_RLS_ROLE_PREFIX)
+
+
+def is_protected_rule_name(name) -> bool:
+    return bool(name) and name.startswith(PLAID_RLS_NAME_STEM)
+
+
+def is_automation_principal() -> bool:
+    """True only for the one Superset user plaid's own service calls
+    authenticate as -- see the module docstring. Fails CLOSED if
+    ``PLAID_RLS_AUTOMATION_USERNAME`` is unset: an empty/missing config value
+    must never be read as "no restriction."
+    """
+    automation_username = current_app.config.get('PLAID_RLS_AUTOMATION_USERNAME')
+    if not automation_username:
+        return False
+    user = getattr(g, 'user', None)
+    username = getattr(user, 'username', None)
+    return username is not None and username == automation_username
+
+
+def _denied(api, name):
+    logger.warning(
+        "Blocked write to protected RLS resource %r by user %r (automation "
+        "principal required).",
+        name,
+        getattr(getattr(g, 'user', None), 'username', None),
+    )
+    return api.response_403(message=DENIAL_MESSAGE.format(name=name))
+
+
+class PlaidRoleApi:
+    """Mixin applied ahead of the vendor Role API subclass -- see wiring notes
+    in ``plaid/security.py``. Guards the four writes that can affect a
+    `plaid_rls_*` role's membership or existence; read/list/permission routes
+    are untouched.
+    """
+
+    def post(self):
+        from flask import request
+        name = (request.json or {}).get('name') if request.is_json else None
+        if is_protected_role_name(name) and not is_automation_principal():
+            return _denied(self, name)
+        return super().post()
+
+    def put(self, pk):
+        from flask import request
+        existing = self.datamodel.get(pk)
+        requested_name = (request.json or {}).get('name') if request.is_json else None
+        current_name = existing.name if existing else None
+        # Whichever of the two names is actually the protected one drives
+        # both the check and the message -- a rename INTO the prefix must
+        # name the (protected) requested name, not the (unprotected) current
+        # one, and vice versa for a rename away from it.
+        protected_name = next(
+            (n for n in (current_name, requested_name) if is_protected_role_name(n)),
+            None,
+        )
+        if protected_name and not is_automation_principal():
+            return _denied(self, protected_name)
+        return super().put(pk)
+
+    def delete(self, pk):
+        existing = self.datamodel.get(pk)
+        name = existing.name if existing else None
+        if is_protected_role_name(name) and not is_automation_principal():
+            return _denied(self, name)
+        return super().delete(pk)
+
+    def update_role_users(self, pk):
+        existing = self.datamodel.get(pk)
+        name = existing.name if existing else None
+        if is_protected_role_name(name) and not is_automation_principal():
+            return _denied(self, name)
+        return super().update_role_users(pk)
+
+
+def _guard_rls_rule_write(get_names):
+    """Wrap an `RLSRestApi` method: block it when any name `get_names(self,
+    *args, **kwargs)` returns is protected and the caller is not the
+    automation principal. `get_names` returns a list so `bulk_delete` (many
+    rules per call) and the single-item routes share one wrapper.
+    """
+    def decorator(method):
+        @functools.wraps(method)
+        def wrapped(self, *args, **kwargs):
+            names = get_names(self, *args, **kwargs)
+            protected = [n for n in names if is_protected_rule_name(n)]
+            if protected and not is_automation_principal():
+                return _denied(self, protected[0])
+            return method(self, *args, **kwargs)
+        return wrapped
+    return decorator
+
+
+def _post_names(api):
+    from flask import request
+    name = (request.json or {}).get('name') if request.is_json else None
+    return [name] if name else []
+
+
+def _put_names(api, pk):
+    from flask import request
+    existing = api.datamodel.get(pk)
+    names = [existing.name] if existing else []
+    requested = (request.json or {}).get('name') if request.is_json else None
+    if requested:
+        names.append(requested)
+    return names
+
+
+def _delete_names(api, pk):
+    existing = api.datamodel.get(pk)
+    return [existing.name] if existing else []
+
+
+def _bulk_delete_names(api, **kwargs):
+    item_ids = kwargs.get('rison') or []
+    names = []
+    for pk in item_ids:
+        row = api.datamodel.get(pk)
+        if row is not None:
+            names.append(row.name)
+    return names
+
+
+def install() -> None:
+    """Monkeypatch `RLSRestApi`'s four write routes in place. Idempotent --
+    safe to call more than once (e.g. module re-import under a reloader).
+    """
+    from superset.row_level_security.api import RLSRestApi
+
+    if getattr(RLSRestApi, '_plaid_rls_guard_installed', False):
+        return
+
+    RLSRestApi.post = _guard_rls_rule_write(_post_names)(RLSRestApi.post)
+    RLSRestApi.put = _guard_rls_rule_write(_put_names)(RLSRestApi.put)
+    RLSRestApi.delete = _guard_rls_rule_write(_delete_names)(RLSRestApi.delete)
+    RLSRestApi.bulk_delete = _guard_rls_rule_write(_bulk_delete_names)(RLSRestApi.bulk_delete)
+    RLSRestApi._plaid_rls_guard_installed = True
+    logger.info('plaid_rls write guard installed on RLSRestApi.')

--- a/plaid/rls_guard.py
+++ b/plaid/rls_guard.py
@@ -110,8 +110,14 @@ Superset differently:
   ``SupersetSecurityManager`` sets it to ``SupersetRoleApi`` (see
   ``superset/security/manager.py``) so that FAB's own
   ``register_views()`` -> ``self.appbuilder.add_api(self.role_api)`` picks up
-  the subclass. ``PlaidRoleApi`` here extends that same subclass; wiring it in
-  is one line on ``PlaidSecurityManager`` (``role_api = PlaidRoleApi``).
+  the subclass. ``PlaidRoleApi`` here extends ``RoleApi`` directly (the same
+  class ``SupersetRoleApi`` extends) -- not as a bare mixin: it is always
+  combined with ``SupersetRoleApi`` at the point it is actually used
+  (``plaid/security.py``'s ``_PlaidGuardedRoleApi``), and declaring the real
+  shared ancestor is both correct typing (mypy can see ``post``/``put``/
+  ``delete``/``update_role_users``/``datamodel`` are genuinely inherited, not
+  merely hoped for) and a truer statement of the contract than an untyped
+  mixin would be.
 * RLS rules: ``RLSRestApi`` (``superset/row_level_security/api.py``) has no
   equivalent override attribute -- Superset registers the class directly. Its
   ``post`` / ``put`` / ``delete`` / ``bulk_delete`` are monkeypatched in place
@@ -128,8 +134,15 @@ from __future__ import annotations
 
 import functools
 import logging
+from typing import Any, Callable, TYPE_CHECKING
 
-from flask import current_app, g
+from flask import current_app, g, Response
+from flask_appbuilder.security.sqla.apis import RoleApi
+
+if TYPE_CHECKING:
+    from flask_appbuilder.api import BaseApi
+    from flask_appbuilder.security.sqla.models import Group, Role, User
+    from sqlalchemy.orm.attributes import Event
 
 logger = logging.getLogger(__name__)
 
@@ -137,8 +150,8 @@ logger = logging.getLogger(__name__)
 # a guard). Rules use this stem with either `_` (Regular) or `guard_`
 # (Base guard) after it -- `is_protected_rule_name` checks the shorter,
 # underscore-less stem so both survive one check.
-PLAID_RLS_ROLE_PREFIX = 'plaid_rls_'
-PLAID_RLS_NAME_STEM = 'plaid_rls'
+PLAID_RLS_ROLE_PREFIX = "plaid_rls_"
+PLAID_RLS_NAME_STEM = "plaid_rls"
 
 DENIAL_MESSAGE = (
     "{name!r} is a PlaidCloud-generated row-access resource. It can only be "
@@ -146,12 +159,16 @@ DENIAL_MESSAGE = (
 )
 
 
-def is_protected_role_name(name) -> bool:
-    return bool(name) and name.startswith(PLAID_RLS_ROLE_PREFIX)
+def is_protected_role_name(name: str | None) -> bool:
+    # `is not None` rather than `bool(name)`: both treat `''` the same way
+    # (an empty string is falsy either way, and `''.startswith(...)` would
+    # correctly return False regardless), but only `is not None` is a form
+    # mypy recognizes as narrowing `name` from `str | None` to `str`.
+    return name is not None and name.startswith(PLAID_RLS_ROLE_PREFIX)
 
 
-def is_protected_rule_name(name) -> bool:
-    return bool(name) and name.startswith(PLAID_RLS_NAME_STEM)
+def is_protected_rule_name(name: str | None) -> bool:
+    return name is not None and name.startswith(PLAID_RLS_NAME_STEM)
 
 
 def _session_is_oauth() -> bool:
@@ -163,7 +180,8 @@ def _session_is_oauth() -> bool:
     username alone is attacker-controlled input on the OAuth path.
     """
     from flask import session
-    return 'oauth' in session
+
+    return "oauth" in session
 
 
 def is_automation_principal() -> bool:
@@ -173,44 +191,59 @@ def is_automation_principal() -> bool:
     must never be read as "no restriction." Also fails closed on an
     OAuth-derived session regardless of username -- see `_session_is_oauth`.
     """
-    automation_username = current_app.config.get('PLAID_RLS_AUTOMATION_USERNAME')
+    automation_username = current_app.config.get("PLAID_RLS_AUTOMATION_USERNAME")
     if not automation_username:
         return False
     if _session_is_oauth():
         return False
-    user = getattr(g, 'user', None)
-    username = getattr(user, 'username', None)
+    user = getattr(g, "user", None)
+    username = getattr(user, "username", None)
     return username is not None and username == automation_username
 
 
-def _denied(api, name):
+def _denied(api: "BaseApi", name: str | None) -> Response:
+    """Build the refusal response. Deliberately calls the generic
+    ``BaseApi.response(code, **kwargs)`` rather than ``response_403()`` --
+    FAB 5.0.2's ``response_403`` takes NO ``message`` argument at all
+    (``def response_403(self) -> Response``, hardcoded to "Forbidden"; no
+    subclass in FAB or this fork overrides it). ``response_400``/
+    ``response_422`` both build their own message the same way this does.
+    The earlier version of this file called ``response_403(message=...)``,
+    which would have raised ``TypeError`` at the first real invocation --
+    masked in testing by a hand-rolled mock that (wrongly) accepted the
+    kwarg the real method does not.
+    """
     logger.warning(
         "Blocked write to protected RLS resource %r by user %r (automation "
         "principal required).",
         name,
-        getattr(getattr(g, 'user', None), 'username', None),
+        getattr(getattr(g, "user", None), "username", None),
     )
-    return api.response_403(message=DENIAL_MESSAGE.format(name=name))
+    return api.response(403, message=DENIAL_MESSAGE.format(name=name))
 
 
-class PlaidRoleApi:
-    """Mixin applied ahead of the vendor Role API subclass -- see wiring notes
-    in ``plaid/security.py``. Guards the four writes that can affect a
-    `plaid_rls_*` role's membership or existence; read/list/permission routes
-    are untouched.
+class PlaidRoleApi(RoleApi):
+    """Guard mixin for the vendor Role API -- see the wiring notes in the
+    module docstring and in ``plaid/security.py``. Guards the four writes
+    that can affect a `plaid_rls_*` role's membership or existence;
+    read/list/permission routes are untouched. Declared as a `RoleApi`
+    subclass (not a bare mixin) because it is always combined with
+    `SupersetRoleApi` at its point of use -- see the module docstring.
     """
 
-    def post(self):
+    def post(self) -> Response:
         from flask import request
-        name = (request.json or {}).get('name') if request.is_json else None
+
+        name = (request.json or {}).get("name") if request.is_json else None
         if is_protected_role_name(name) and not is_automation_principal():
             return _denied(self, name)
         return super().post()
 
-    def put(self, pk):
+    def put(self, pk: int) -> Response:
         from flask import request
+
         existing = self.datamodel.get(pk)
-        requested_name = (request.json or {}).get('name') if request.is_json else None
+        requested_name = (request.json or {}).get("name") if request.is_json else None
         current_name = existing.name if existing else None
         # Whichever of the two names is actually the protected one drives
         # both the check and the message -- a rename INTO the prefix must
@@ -224,14 +257,14 @@ class PlaidRoleApi:
             return _denied(self, protected_name)
         return super().put(pk)
 
-    def delete(self, pk):
+    def delete(self, pk: int) -> Response:
         existing = self.datamodel.get(pk)
         name = existing.name if existing else None
         if is_protected_role_name(name) and not is_automation_principal():
             return _denied(self, name)
         return super().delete(pk)
 
-    def update_role_users(self, pk):
+    def update_role_users(self, pk: int) -> Response:
         existing = self.datamodel.get(pk)
         name = existing.name if existing else None
         if is_protected_role_name(name) and not is_automation_principal():
@@ -239,47 +272,56 @@ class PlaidRoleApi:
         return super().update_role_users(pk)
 
 
-def _guard_rls_rule_write(get_names):
+GetNamesFn = Callable[..., list[str]]
+RlsRouteFn = Callable[..., Response]
+
+
+def _guard_rls_rule_write(get_names: GetNamesFn) -> Callable[[RlsRouteFn], RlsRouteFn]:
     """Wrap an `RLSRestApi` method: block it when any name `get_names(self,
     *args, **kwargs)` returns is protected and the caller is not the
     automation principal. `get_names` returns a list so `bulk_delete` (many
     rules per call) and the single-item routes share one wrapper.
     """
-    def decorator(method):
+
+    def decorator(method: RlsRouteFn) -> RlsRouteFn:
         @functools.wraps(method)
-        def wrapped(self, *args, **kwargs):
+        def wrapped(self: "BaseApi", *args: Any, **kwargs: Any) -> Response:
             names = get_names(self, *args, **kwargs)
             protected = [n for n in names if is_protected_rule_name(n)]
             if protected and not is_automation_principal():
                 return _denied(self, protected[0])
             return method(self, *args, **kwargs)
+
         return wrapped
+
     return decorator
 
 
-def _post_names(api):
+def _post_names(api: "BaseApi") -> list[str]:
     from flask import request
-    name = (request.json or {}).get('name') if request.is_json else None
+
+    name = (request.json or {}).get("name") if request.is_json else None
     return [name] if name else []
 
 
-def _put_names(api, pk):
+def _put_names(api: "BaseApi", pk: int) -> list[str]:
     from flask import request
+
     existing = api.datamodel.get(pk)
     names = [existing.name] if existing else []
-    requested = (request.json or {}).get('name') if request.is_json else None
+    requested = (request.json or {}).get("name") if request.is_json else None
     if requested:
         names.append(requested)
     return names
 
 
-def _delete_names(api, pk):
+def _delete_names(api: "BaseApi", pk: int) -> list[str]:
     existing = api.datamodel.get(pk)
     return [existing.name] if existing else []
 
 
-def _bulk_delete_names(api, **kwargs):
-    item_ids = kwargs.get('rison') or []
+def _bulk_delete_names(api: "BaseApi", **kwargs: Any) -> list[str]:
+    item_ids = kwargs.get("rison") or []
     names = []
     for pk in item_ids:
         row = api.datamodel.get(pk)
@@ -294,15 +336,17 @@ def install() -> None:
     """
     from superset.row_level_security.api import RLSRestApi
 
-    if getattr(RLSRestApi, '_plaid_rls_guard_installed', False):
+    if getattr(RLSRestApi, "_plaid_rls_guard_installed", False):
         return
 
     RLSRestApi.post = _guard_rls_rule_write(_post_names)(RLSRestApi.post)
     RLSRestApi.put = _guard_rls_rule_write(_put_names)(RLSRestApi.put)
     RLSRestApi.delete = _guard_rls_rule_write(_delete_names)(RLSRestApi.delete)
-    RLSRestApi.bulk_delete = _guard_rls_rule_write(_bulk_delete_names)(RLSRestApi.bulk_delete)
+    RLSRestApi.bulk_delete = _guard_rls_rule_write(_bulk_delete_names)(
+        RLSRestApi.bulk_delete
+    )
     RLSRestApi._plaid_rls_guard_installed = True
-    logger.info('plaid_rls write guard installed on RLSRestApi.')
+    logger.info("plaid_rls write guard installed on RLSRestApi.")
 
 
 # --- ORM-level guard: the actual control -----------------------------------
@@ -326,52 +370,55 @@ class PlaidRlsGuardError(Exception):
     """
 
 
-def _group_holds_protected_role(group) -> bool:
-    return any(is_protected_role_name(getattr(r, 'name', None)) for r in group.roles)
+def _group_holds_protected_role(group: "Group") -> bool:
+    return any(is_protected_role_name(getattr(r, "name", None)) for r in group.roles)
 
 
-def _veto_protected_role_grant(role_name) -> None:
+def _veto_protected_role_grant(role_name: str | None) -> None:
     if is_protected_role_name(role_name) and not is_automation_principal():
         logger.warning(
             "Blocked ORM-level grant of protected role %r to user %r "
             "(automation principal required).",
             role_name,
-            getattr(getattr(g, 'user', None), 'username', None),
+            getattr(getattr(g, "user", None), "username", None),
         )
         raise PlaidRlsGuardError(DENIAL_MESSAGE.format(name=role_name))
 
 
-def _guard_role_user_append(role, user, initiator):  # noqa: ARG001 -- SQLAlchemy event signature
+def _guard_role_user_append(role: "Role", user: "User", initiator: "Event") -> None:
     """Fires on `role.user.append(...)` / `role.user = [...]` (RoleApi.
     update_role_users' shape) AND on `user.roles.append(role)` / `user.roles
     = [...]` via the backref (UserApi.put's shape) -- empirically confirmed
     both directions fire this same event; see the test suite.
     """
-    _veto_protected_role_grant(getattr(role, 'name', None))
+    del user, initiator  # unused -- SQLAlchemy's event signature is fixed
+    _veto_protected_role_grant(getattr(role, "name", None))
 
 
-def _guard_group_role_append(group, role, initiator):  # noqa: ARG001
+def _guard_group_role_append(group: "Group", role: "Role", initiator: "Event") -> None:
     """Fires on `group.roles.append(...)` / `group.roles = [...]` (GroupApi's
     shape) AND on `role.groups.append(group)` / `role.groups = [...]` via the
     backref (RoleApi.update_role_groups' shape)."""
-    _veto_protected_role_grant(getattr(role, 'name', None))
+    del group, initiator  # unused -- SQLAlchemy's event signature is fixed
+    _veto_protected_role_grant(getattr(role, "name", None))
 
 
-def _guard_group_user_append(group, user, initiator):  # noqa: ARG001
+def _guard_group_user_append(group: "Group", user: "User", initiator: "Event") -> None:
     """Adding a user to a group that ALREADY holds a protected role grants
     that role's entitlement without ever writing `ab_group_role` -- this is
     the third leg (GroupApi's `users` field, and UserApi.put's `groups`
     field via the backref) and needs its own check: is the GROUP protected,
     not the (irrelevant here) role name."""
+    del initiator  # unused -- SQLAlchemy's event signature is fixed
     if not is_automation_principal() and _group_holds_protected_role(group):
         logger.warning(
             "Blocked ORM-level group-membership grant into %r, which holds a "
             "protected role, for user %r (automation principal required).",
-            getattr(group, 'name', None),
-            getattr(user, 'username', None),
+            getattr(group, "name", None),
+            getattr(user, "username", None),
         )
         raise PlaidRlsGuardError(
-            f'{getattr(group, "name", None)!r} holds a PlaidCloud-generated '
+            f"{getattr(group, 'name', None)!r} holds a PlaidCloud-generated "
             "row-access role. Membership can only be written by PlaidCloud's "
             "own automation."
         )
@@ -389,13 +436,13 @@ def install_orm_listeners() -> None:
     """
     from flask_appbuilder.security.sqla.models import Group, Role
 
-    if getattr(Role, '_plaid_rls_orm_guard_installed', False):
+    if getattr(Role, "_plaid_rls_orm_guard_installed", False):
         return
 
     from sqlalchemy import event
 
-    event.listen(Role.user, 'append', _guard_role_user_append)
-    event.listen(Group.roles, 'append', _guard_group_role_append)
-    event.listen(Group.users, 'append', _guard_group_user_append)
+    event.listen(Role.user, "append", _guard_role_user_append)
+    event.listen(Group.roles, "append", _guard_group_role_append)
+    event.listen(Group.users, "append", _guard_group_user_append)
     Role._plaid_rls_orm_guard_installed = True
-    logger.info('plaid_rls ORM-level role/group guard installed.')
+    logger.info("plaid_rls ORM-level role/group guard installed.")

--- a/plaid/rls_guard.py
+++ b/plaid/rls_guard.py
@@ -23,6 +23,46 @@ scheme produces (sc-23432 non-negotiable 5): roles are always
 role or rule INTO the stem is blocked symmetrically -- a workspace admin
 cannot pre-empt or impersonate a name the reconciler expects to own next.
 
+Also protected -- and this is the part that is NOT expressible as "patch the
+right API methods", see below: acquiring a protected role's entitlement
+*without ever writing the role itself*. `FAB's BaseSecurityManager.
+get_user_roles` (and Superset's `get_rls_filters`, which is what actually
+resolves RLS-rule matching) both compute a user's effective roles as
+``user.roles + [role for group in user.groups for role in group.roles]``
+(`flask_appbuilder/security/manager.py:1519`). So a `plaid_rls_*` role's
+entitlement is ALSO reachable via:
+
+- `RoleApi.update_role_groups` -- ``PUT /api/v1/security/roles/{id}/groups``
+  (FAB, `security/sqla/apis/role/api.py:236-306``, sets ``role.groups = [...]``);
+- `GroupApi` -- registered whenever ``FAB_ADD_SECURITY_API`` is true (it is,
+  both in Superset's own `config.py` default and in every deployed tenant
+  config), full CRUD, `edit_columns` include both ``users`` and ``roles``
+  (`security/sqla/apis/group/api.py`) -- one `POST` creates a group holding
+  the target role with the attacker as a member;
+- `UserApi.put` -- the GENERIC ``PUT /api/v1/security/users/{id}`` (distinct
+  from `RoleApi.update_role_users`), whose `edit_columns` also include both
+  ``roles`` and ``groups`` (`security/sqla/apis/user/api.py:45-54`) and which
+  `SupersetUserApi` does not restrict.
+
+None of those three go through the methods the first draft of this guard
+patched. **This is not an accident of coverage -- it is the general case.**
+Enumerating write-capable API methods is provably incomplete: this file's
+own first version missed three of them on its first pass, found only by an
+independent review reasoning from the schema outward rather than from the
+route table. The fix is therefore NOT "patch three more methods" -- it is
+`install_orm_listeners()` below, which vetoes the underlying SQLAlchemy
+collection mutation directly, at the three association tables every one of
+those paths (and any future one -- a CLI script, a bulk importer, a
+not-yet-written admin action) must ultimately write through: ``ab_user_role``,
+``ab_group_role``, ``ab_user_group``. A relationship-collection append fires
+its event before any SQL is issued and regardless of which side of a
+backref-paired relationship (`Role.user` / `User.roles`, `Group.roles` /
+`Role.groups`, `Group.users` / `User.groups`) triggered it -- verified
+empirically, not assumed; see the test suite. The per-route guards
+(`PlaidRoleApi`, `install()`) stay as defense-in-depth -- they give a clean
+403 instead of a 500 for the common case -- but the ORM listeners are the
+actual control.
+
 NOT protected here, disclosed rather than silently assumed to be covered:
 dataset identity. ``DatasetPutSchema`` lets a dataset owner rewrite
 ``table_name`` / ``schema`` / ``catalog`` / ``sql`` behind
@@ -30,6 +70,12 @@ dataset identity. ``DatasetPutSchema`` lets a dataset owner rewrite
 generated rule's binding at different data without touching the rule or role
 this guard watches at all. Out of scope for Part 4; see sc-23432 (referenced by
 description only -- do not cite it in commits/branches/PRs in THIS repo).
+
+Also NOT protected, and not something an ORM listener can reach: a write
+that never goes through the SQLAlchemy ORM at all -- a raw ``INSERT INTO
+ab_user_role`` issued outside this application (direct DB access, a
+different service sharing the metadata DB). That is a different trust
+boundary than this guard is written against.
 
 ## Who may write a protected resource
 
@@ -42,6 +88,18 @@ role via an ``is_admin`` claim -- is a DIFFERENT ``ab_user`` row, self-
 registered on first login by ``PlaidSecurityManager.auth_user_oauth``, and is
 refused here regardless of role. Unconfigured (``None`` / empty string) fails
 CLOSED: nobody may write a protected resource, not "anyone may."
+
+The username check alone is not quite enough: `oauth_user_info`
+(`plaid/security.py`) derives the OAuth login's username from a Keycloak
+claim (`data.get("name", data["preferred_username"])`) that the logging-in
+user's own IdP profile controls, so a Keycloak account whose display name or
+username happens to collide with the automation username cannot be ruled
+out by name alone. `is_automation_principal` additionally requires that the
+CURRENT request was not authenticated via an OAuth session -- FAB stamps
+``session['oauth']`` only on the OAuth login path (`security/manager.py:592`),
+never on a JWT-bearer API call (which is how plaid's own automation always
+authenticates, `provider: 'db'`) -- so an OAuth-derived session can never
+satisfy this check regardless of what username it carries.
 
 ## Why this lives in ``plaid/``, and how it attaches
 
@@ -96,14 +154,29 @@ def is_protected_rule_name(name) -> bool:
     return bool(name) and name.startswith(PLAID_RLS_NAME_STEM)
 
 
+def _session_is_oauth() -> bool:
+    """True iff the CURRENT request authenticated via an OAuth-derived
+    session. FAB stamps ``session['oauth']`` only on that path
+    (`security/manager.py:592`) -- a JWT-bearer API call, which is how
+    plaid's own automation always authenticates, never sets it. See the
+    module docstring's "who may write" section for why this matters: the
+    username alone is attacker-controlled input on the OAuth path.
+    """
+    from flask import session
+    return 'oauth' in session
+
+
 def is_automation_principal() -> bool:
     """True only for the one Superset user plaid's own service calls
     authenticate as -- see the module docstring. Fails CLOSED if
     ``PLAID_RLS_AUTOMATION_USERNAME`` is unset: an empty/missing config value
-    must never be read as "no restriction."
+    must never be read as "no restriction." Also fails closed on an
+    OAuth-derived session regardless of username -- see `_session_is_oauth`.
     """
     automation_username = current_app.config.get('PLAID_RLS_AUTOMATION_USERNAME')
     if not automation_username:
+        return False
+    if _session_is_oauth():
         return False
     user = getattr(g, 'user', None)
     username = getattr(user, 'username', None)
@@ -230,3 +303,99 @@ def install() -> None:
     RLSRestApi.bulk_delete = _guard_rls_rule_write(_bulk_delete_names)(RLSRestApi.bulk_delete)
     RLSRestApi._plaid_rls_guard_installed = True
     logger.info('plaid_rls write guard installed on RLSRestApi.')
+
+
+# --- ORM-level guard: the actual control -----------------------------------
+#
+# See the module docstring's "What this protects" section for why route
+# patching alone is insufficient. These three listeners sit on the
+# association-table relationships every path to "this user's effective role
+# set includes a plaid_rls_* role" must write through, regardless of which
+# REST route, CLI command, or future code path performs the write.
+
+
+class PlaidRlsGuardError(Exception):
+    """Raised from inside a SQLAlchemy collection-mutation event to veto it.
+    Propagates up through whatever ORM call triggered the mutation (a route
+    handler, a script, a shell command) -- there is no single HTTP layer to
+    convert this to a clean status code for every caller, so it surfaces as
+    whatever that caller does with an uncaught exception. For the REST routes
+    this still reaches (FAB's `@safe` maps an uncaught exception to a 500),
+    the write is refused either way; the per-route guards above exist to give
+    the common case a clean 403 before the ORM layer is ever reached.
+    """
+
+
+def _group_holds_protected_role(group) -> bool:
+    return any(is_protected_role_name(getattr(r, 'name', None)) for r in group.roles)
+
+
+def _veto_protected_role_grant(role_name) -> None:
+    if is_protected_role_name(role_name) and not is_automation_principal():
+        logger.warning(
+            "Blocked ORM-level grant of protected role %r to user %r "
+            "(automation principal required).",
+            role_name,
+            getattr(getattr(g, 'user', None), 'username', None),
+        )
+        raise PlaidRlsGuardError(DENIAL_MESSAGE.format(name=role_name))
+
+
+def _guard_role_user_append(role, user, initiator):  # noqa: ARG001 -- SQLAlchemy event signature
+    """Fires on `role.user.append(...)` / `role.user = [...]` (RoleApi.
+    update_role_users' shape) AND on `user.roles.append(role)` / `user.roles
+    = [...]` via the backref (UserApi.put's shape) -- empirically confirmed
+    both directions fire this same event; see the test suite.
+    """
+    _veto_protected_role_grant(getattr(role, 'name', None))
+
+
+def _guard_group_role_append(group, role, initiator):  # noqa: ARG001
+    """Fires on `group.roles.append(...)` / `group.roles = [...]` (GroupApi's
+    shape) AND on `role.groups.append(group)` / `role.groups = [...]` via the
+    backref (RoleApi.update_role_groups' shape)."""
+    _veto_protected_role_grant(getattr(role, 'name', None))
+
+
+def _guard_group_user_append(group, user, initiator):  # noqa: ARG001
+    """Adding a user to a group that ALREADY holds a protected role grants
+    that role's entitlement without ever writing `ab_group_role` -- this is
+    the third leg (GroupApi's `users` field, and UserApi.put's `groups`
+    field via the backref) and needs its own check: is the GROUP protected,
+    not the (irrelevant here) role name."""
+    if not is_automation_principal() and _group_holds_protected_role(group):
+        logger.warning(
+            "Blocked ORM-level group-membership grant into %r, which holds a "
+            "protected role, for user %r (automation principal required).",
+            getattr(group, 'name', None),
+            getattr(user, 'username', None),
+        )
+        raise PlaidRlsGuardError(
+            f'{getattr(group, "name", None)!r} holds a PlaidCloud-generated '
+            "row-access role. Membership can only be written by PlaidCloud's "
+            "own automation."
+        )
+
+
+def install_orm_listeners() -> None:
+    """Attach the three association-table veto listeners. Idempotent.
+
+    Deliberately does NOT also listen on the `remove` event -- revoking
+    access is not the risk this guards against, and vetoing removal would
+    make it impossible for PlaidCloud's own reconciler to ever narrow a
+    grant without also being the automation principal for the remove call,
+    which it always is, but there is no reason to make that a requirement
+    of the model.
+    """
+    from flask_appbuilder.security.sqla.models import Group, Role
+
+    if getattr(Role, '_plaid_rls_orm_guard_installed', False):
+        return
+
+    from sqlalchemy import event
+
+    event.listen(Role.user, 'append', _guard_role_user_append)
+    event.listen(Group.roles, 'append', _guard_group_role_append)
+    event.listen(Group.users, 'append', _guard_group_user_append)
+    Role._plaid_rls_orm_guard_installed = True
+    logger.info('plaid_rls ORM-level role/group guard installed.')

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -99,6 +99,11 @@ class PlaidSecurityManager(SupersetSecurityManager):
         # module-load time. See `plaid/rls_guard.py`.
         rls_guard.install()
 
+        # The actual control for role/group escalation -- see rls_guard's
+        # module docstring "What this protects" section for why route
+        # patching alone (RoleApi above) is not enough on its own.
+        rls_guard.install_orm_listeners()
+
         if self.auth_type == AUTH_OAUTH:
             self.authoauthview = PlaidAuthOAuthView
 

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -19,11 +19,13 @@ from requests.exceptions import HTTPError
 
 from plaidcloud.rpc.connection.jsonrpc import SimpleRPC
 from plaid.auth_oidc import PlaidAuthOAuthView
+from plaid import rls_guard
 # from plaid.blacklist_api import is_token_blacklisted
 # from plaid.auth_oidc import AuthOIDCView
 # from plaid.blacklist_api import TokenBlacklistApi
 
 from superset.security import SupersetSecurityManager
+from superset.security.manager import SupersetRoleApi
 
 from sqlalchemy import func
 
@@ -39,6 +41,14 @@ log = logging.getLogger(__name__)
 USE_REFRESH_TOKENS = False
 PROJECT_ACCESS = 'project_access'
 
+
+class _PlaidGuardedRoleApi(rls_guard.PlaidRoleApi, SupersetRoleApi):
+    """`PlaidRoleApi`'s guard methods call `super()` on the allowed path,
+    which MRO resolves to `SupersetRoleApi` / FAB's `RoleApi` -- so a
+    legitimate write (the automation principal, or a role outside the
+    `plaid_rls_` prefix) behaves exactly as upstream, including
+    `SupersetRoleApi.pre_delete`'s permission-clearing override.
+    """
 
 
 class PlaidSecurityManager(SupersetSecurityManager):
@@ -66,6 +76,10 @@ class PlaidSecurityManager(SupersetSecurityManager):
         "UserRegistrationsRestAPI",
     }
 
+    # sc-23432 Part 4 -- protects `plaid_rls_*` roles from write access by
+    # anyone but the automation principal. See `plaid/rls_guard.py`.
+    role_api = _PlaidGuardedRoleApi
+
     def __init__(self, appbuilder):
         # These allowed me to turn this on without adjusting the superset_config.py
         # app = appbuilder.get_app
@@ -73,6 +87,17 @@ class PlaidSecurityManager(SupersetSecurityManager):
         # app.config['AUTH_USER_REGISTRATION'] = True
         # app.config['AUTH_ROLES_SYNC_AT_LOGIN'] = True
         super().__init__(appbuilder)
+
+        # sc-23432 Part 4 -- the RLS rules API (`RowLevelSecurityFilter`) has
+        # no override attribute like `role_api` above; `RLSRestApi`'s write
+        # routes are patched in place instead. Here, not at module import
+        # time: `RLSRestApi` pulls in Superset's command/DAO layer, which
+        # this constructor -- running after `super().__init__`, well after
+        # Superset's own app factory has set up its view registry, and still
+        # well before the app accepts its first request -- is a safer point
+        # to depend on than being importable at `plaid.security`'s own
+        # module-load time. See `plaid/rls_guard.py`.
+        rls_guard.install()
 
         if self.auth_type == AUTH_OAUTH:
             self.authoauthview = PlaidAuthOAuthView

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -2,32 +2,32 @@
 """
 Plaid Security Class for Superset
 """
-import logging
-import uuid
-import time
-import jwt
-from typing import Union, List, Optional
-from typing_extensions import override
 
+import logging
+import time
+import uuid
+from typing import List, Optional, Union
 from urllib.parse import urljoin
+
+import jwt
+from authlib.integrations.flask_client import token_update
 from flask import session
-from flask_login import logout_user
 from flask_appbuilder import Model
 from flask_appbuilder.security.manager import AUTH_OAUTH
-from authlib.integrations.flask_client import token_update
-from requests.exceptions import HTTPError
-
+from flask_login import logout_user
 from plaidcloud.rpc.connection.jsonrpc import SimpleRPC
-from plaid.auth_oidc import PlaidAuthOAuthView
+from requests.exceptions import HTTPError
+from sqlalchemy import func
+from typing_extensions import override
+
 from plaid import rls_guard
+from plaid.auth_oidc import PlaidAuthOAuthView
+
 # from plaid.blacklist_api import is_token_blacklisted
 # from plaid.auth_oidc import AuthOIDCView
 # from plaid.blacklist_api import TokenBlacklistApi
-
 from superset.security import SupersetSecurityManager
 from superset.security.manager import SupersetRoleApi
-
-from sqlalchemy import func
 
 __author__ = "Garrett Bates"
 __copyright__ = "© Copyright 2018=2026, PlaidCloud, Inc"
@@ -39,7 +39,7 @@ __email__ = "garrett.bates@plaidcloud.com"
 
 log = logging.getLogger(__name__)
 USE_REFRESH_TOKENS = False
-PROJECT_ACCESS = 'project_access'
+PROJECT_ACCESS = "project_access"
 
 
 class _PlaidGuardedRoleApi(rls_guard.PlaidRoleApi, SupersetRoleApi):
@@ -52,8 +52,7 @@ class _PlaidGuardedRoleApi(rls_guard.PlaidRoleApi, SupersetRoleApi):
 
 
 class PlaidSecurityManager(SupersetSecurityManager):
-    """Custom security manager class for PlaidCloud integration.
-    """
+    """Custom security manager class for PlaidCloud integration."""
 
     # The admin SPA routes (UsersListView, RolesListView, GroupsListView,
     # ActionLogView, UserRegistrationsView) all gate on the ("read", "security")
@@ -121,7 +120,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
             # item.refresh_token = token.get('refresh_token')
             # item.expires_at = token['expires_at']
             # item.save()
-            log.info(f'Updated token for {name} - {repr(token)}')
+            log.info(f"Updated token for {name} - {repr(token)}")
             self.appbuilder.sm.set_oauth_session(name, token)
 
     # def register_views(self) -> None:
@@ -131,7 +130,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def oauth_user_info(self, provider, response=None):
         # logging.debug("Oauth2 provider: {0}.".format(provider))
-        if provider == 'plaidkeycloak':
+        if provider == "plaidkeycloak":
             me = self.appbuilder.sm.oauth_remotes[provider].get("userinfo")
             me.raise_for_status()
             data = me.json()
@@ -146,24 +145,28 @@ class PlaidSecurityManager(SupersetSecurityManager):
             #     role_keys.append('superset-admin')
 
             # This is for using Keycloak roles - have to inspect the token
-            access_token = response.get('access_token')
-            decoded_token = jwt.decode(access_token, options={'verify_signature': False})
-            roles = set(decoded_token.get('realm_access', {}).get('roles', []))
-            log.debug('Decoded token: %s', decoded_token)
-            log.debug('Roles from token: %s', roles)
+            access_token = response.get("access_token")
+            decoded_token = jwt.decode(
+                access_token, options={"verify_signature": False}
+            )
+            roles = set(decoded_token.get("realm_access", {}).get("roles", []))
+            log.debug("Decoded token: %s", decoded_token)
+            log.debug("Roles from token: %s", roles)
             role_keys = []
-            if 'dashboard.dashboard.read' in roles:
-                role_keys.append('superset-gamma')
-            if 'dashboard.dashboard.write' in roles:
-                role_keys.append('superset-alpha')
-            if decoded_token.get('is_admin', False):
-                role_keys.append('superset-admin')
+            if "dashboard.dashboard.read" in roles:
+                role_keys.append("superset-gamma")
+            if "dashboard.dashboard.write" in roles:
+                role_keys.append("superset-alpha")
+            if decoded_token.get("is_admin", False):
+                role_keys.append("superset-admin")
             return {
-                "username": data.get("name", data["preferred_username"]), # this matches OIDC implementation
+                "username": data.get(
+                    "name", data["preferred_username"]
+                ),  # this matches OIDC implementation
                 "first_name": data.get("given_name", ""),
                 "last_name": data.get("family_name", ""),
                 "email": data.get("email", ""),
-                "role_keys": role_keys  # These role_keys get mapped to real roles via the AUTH_ROLES_MAPPING config value
+                "role_keys": role_keys,  # These role_keys get mapped to real roles via the AUTH_ROLES_MAPPING config value
             }
 
     @override
@@ -248,7 +251,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
             return None
 
         # Sync the user's roles
-        if user and len(user.roles) == 0: # self.auth_roles_sync_at_login:
+        if user and len(user.roles) == 0:  # self.auth_roles_sync_at_login:
             user.roles = self._oauth_calculate_user_roles(userinfo)
             log.debug("Calculated new roles for user='%s' as: %s", email, user.roles)
 
@@ -318,18 +321,18 @@ class PlaidSecurityManager(SupersetSecurityManager):
     #     perm = self.get_perms().get(pvm.permission.name)
     #     return bool(perm) and pvm.view_menu.name in perm
 
-
     def get_rpc(self) -> SimpleRPC:
         base_url = f"http://{self.appbuilder.app.config.get('PLAID_RPC')}"
         rpc_url = urljoin(base_url, "json-rpc/")
 
         if self.auth_type == AUTH_OAUTH:
-            rpc_token, secret = session['oauth']
+            rpc_token, secret = session["oauth"]
         else:
-            rpc_token = session['token']['access_token']
+            rpc_token = session["token"]["access_token"]
 
         rpc = SimpleRPC(rpc_token, uri=rpc_url, verify_ssl=False)
         rpc._old_call_rpc = rpc.call_rpc
+
         def superset_call_rpc(*args, **kwargs):
             try:
                 return rpc._old_call_rpc(*args, **kwargs)
@@ -338,8 +341,8 @@ class PlaidSecurityManager(SupersetSecurityManager):
                     logout_user()
                     session.clear()
                     raise Exception(
-                        'There were problems authenticating your access with PlaidCloud. '
-                        'If you see this message, please refresh your browser'
+                        "There were problems authenticating your access with PlaidCloud. "
+                        "If you see this message, please refresh your browser"
                     ) from e
                 raise
 
@@ -363,10 +366,9 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def can_access_database(self, database: Union["Database"]) -> bool:
         log.info(f"Can access database: {database}")
-        return (
-            self._can_access_project(str(database.uuid))
-            or super().can_access_database(database)
-        )
+        return self._can_access_project(
+            str(database.uuid)
+        ) or super().can_access_database(database)
 
     def can_access_datasource(self, datasource: "BaseDatasource") -> bool:
         log.info(f"Checking access to datasource: {datasource}")
@@ -377,15 +379,17 @@ class PlaidSecurityManager(SupersetSecurityManager):
             return super().can_access_datasource(datasource)
 
         project_id = str(datasource.database.uuid)
-        return (
-            self._can_access_project(project_id)
-            or super().can_access_datasource(datasource)
+        return self._can_access_project(project_id) or super().can_access_datasource(
+            datasource
         )
 
     def is_owner(self, resource: Model) -> bool:
         from superset.models.slice import Slice  # a Slice is a chart
+
         if isinstance(resource, Slice):
-            return super().is_owner(resource) or any([self.is_owner(dashboard) for dashboard in resource.dashboards])
+            return super().is_owner(resource) or any(
+                [self.is_owner(dashboard) for dashboard in resource.dashboards]
+            )
 
         return super().is_owner(resource)
 
@@ -407,6 +411,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def _get_project_dbs(self):
         from superset.models.core import Database
+
         if PROJECT_ACCESS not in session:
             if self.is_admin():
                 return self.session.query(Database)
@@ -415,7 +420,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
         return self.session.query(Database).filter(Database.uuid.in_(project_uuids))
 
     def user_view_menu_names(self, permission_name: str) -> set[str]:
-        if permission_name == 'database_access':
+        if permission_name == "database_access":
             project_perms = {db.perm for db in self._get_project_dbs()}
             return project_perms | super().user_view_menu_names(permission_name)
 
@@ -427,22 +432,21 @@ class PlaidSecurityManager(SupersetSecurityManager):
     # According to unpack_database_and_schema, it looks like a schema_permission looks like [database_name].[schema|table] , I think with the square brackets included.
     # unpack_database_and_schema is run on the things erturned by user_view_menu_names
     # so is the regex in get_accessible_databases()
-    #Looks like maybe it's [database_name].[schema|table].id:<id> (where the first id is literal, the second is an id)
+    # Looks like maybe it's [database_name].[schema|table].id:<id> (where the first id is literal, the second is an id)
     # Actual examples:
- # ('all_database_access',),
- # ('all_query_access',),
- # ('[International Motors (21dc)].(id:1)',),
- # ('[International Motors (21dc)].[anlz21dccece-1043-4c10-9bb5-c512ca4d5393]',),
- # ('[International Motors (21dc)].[anlze395fd34-fedc-4f04-b3fd-c50d8d77c531]',),
- # ('[International Motors (21dc)].[gp_toolkit]',),
- # ('[International Motors (21dc)].[information_schema]',),
- # ('[International Motors (21dc)].[public]',),
- # ('Profile',),
- # ('[International Motors (21dc)].[ParentChildRecord](id:50)',),
- # ('[International Motors (21dc)].[ActivityDriverValueRecord](id:51)',),
- # ('[International Motors (21dc)].[ResourceDriverSplitRecord](id:52)',),
- # ('[International Motors (21dc)].[ResourceDriverValueRecord](id:53)',)
-
+    # ('all_database_access',),
+    # ('all_query_access',),
+    # ('[International Motors (21dc)].(id:1)',),
+    # ('[International Motors (21dc)].[anlz21dccece-1043-4c10-9bb5-c512ca4d5393]',),
+    # ('[International Motors (21dc)].[anlze395fd34-fedc-4f04-b3fd-c50d8d77c531]',),
+    # ('[International Motors (21dc)].[gp_toolkit]',),
+    # ('[International Motors (21dc)].[information_schema]',),
+    # ('[International Motors (21dc)].[public]',),
+    # ('Profile',),
+    # ('[International Motors (21dc)].[ParentChildRecord](id:50)',),
+    # ('[International Motors (21dc)].[ActivityDriverValueRecord](id:51)',),
+    # ('[International Motors (21dc)].[ResourceDriverSplitRecord](id:52)',),
+    # ('[International Motors (21dc)].[ResourceDriverValueRecord](id:53)',)
 
     # Not actually necessary to override this, since it depends on user_view_menu_names(), and we're overriding that.
     # def get_accessible_databases():
@@ -450,15 +454,18 @@ class PlaidSecurityManager(SupersetSecurityManager):
     #     # projects accessible under plaid's security system.
     #     return self.get_project_ids() + super().get_accessible_databases()
 
-
     def get_schemas_accessible_by_user(
-            self, database: "Database", catalog: Optional[str], schemas: List[str], hierarchical: bool = True
+        self,
+        database: "Database",
+        catalog: Optional[str],
+        schemas: List[str],
+        hierarchical: bool = True,
     ) -> List[str]:
-        REPORTING_SCHEMA_PREFIX = 'report'
+        REPORTING_SCHEMA_PREFIX = "report"
 
         schema = str(database.uuid)
         if not schema.startswith(REPORTING_SCHEMA_PREFIX):
-            schema = f'{REPORTING_SCHEMA_PREFIX}{schema}'
+            schema = f"{REPORTING_SCHEMA_PREFIX}{schema}"
 
         if schema in schemas:
             return [schema]
@@ -475,7 +482,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
     #     log.debug(f"Fetched table IDs in {end - start}: {table_ids}")
     #     return table_ids
 
-
     # def get_perms(self):
     #     """Accesses plaid permission dictionary from config.
     #
@@ -483,7 +489,6 @@ class PlaidSecurityManager(SupersetSecurityManager):
     #         dict: collection of view menus indexed by permission name.
     #     """
     #     return self.appbuilder.app.config.get('PLAID_BASE_PERMISSIONS')
-
 
     # This looks unused
     # def add_user_to_project(self, user, project_id):
@@ -509,11 +514,10 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
     def has_oauth_token(self):
         if self.auth_type == AUTH_OAUTH:
-            return 'oauth' in session
+            return "oauth" in session
         # if self.auth_type == AUTH_OID:
         #     return 'token' in session
         return False
-
 
     # N.B. This method is called using FLASK_APP_MUTATOR in the superset-config secret
     #  It makes this call to validate the token in a before_request handler
@@ -521,9 +525,9 @@ class PlaidSecurityManager(SupersetSecurityManager):
         def _internal_validate():
             try:
                 if self.auth_type == AUTH_OAUTH:
-                    if 'oauth' in session:
+                    if "oauth" in session:
                         # Basic validation of token expiry
-                        token, secret = session['oauth']
+                        token, secret = session["oauth"]
                         # if is_token_blacklisted(token):
                         #     return False
                         if token_is_valid(token):
@@ -532,16 +536,20 @@ class PlaidSecurityManager(SupersetSecurityManager):
                         if USE_REFRESH_TOKENS:
                             # to do the below, it needs custom `set_oauth_session` to save the `oauth_token_dict`
                             provider = session["oauth_provider"]
-                            token_dict = session['oauth_token_dict']
-                            logging.info('Provider %s, Token %s', provider, token_dict)
+                            token_dict = session["oauth_token_dict"]
+                            logging.info("Provider %s, Token %s", provider, token_dict)
                             # this will refresh the token if it is expired (via `token_update` listener)
-                            self.appbuilder.sm.oauth_remotes[provider].token = token_dict
-                            user_resp = self.appbuilder.sm.oauth_remotes[provider].get("userinfo")
+                            self.appbuilder.sm.oauth_remotes[
+                                provider
+                            ].token = token_dict
+                            user_resp = self.appbuilder.sm.oauth_remotes[provider].get(
+                                "userinfo"
+                            )
                             user_resp.raise_for_status()
-                            logging.info('Got user response')
+                            logging.info("Got user response")
                             # ToDo - probably should check token now refreshed, or use the introspection
 
-                            #ToDo - I could not get introspection to work, I was calling from FlaskOAuth2App, but needs to be and OAuth2Session which is the _get_oauth_client() of the Flask thing
+                            # ToDo - I could not get introspection to work, I was calling from FlaskOAuth2App, but needs to be and OAuth2Session which is the _get_oauth_client() of the Flask thing
                             # maybe we don't need to introspect anyway, can just check expiry.
 
                             # # new token now stored in session
@@ -558,7 +566,7 @@ class PlaidSecurityManager(SupersetSecurityManager):
                 return False
 
             except Exception as e:
-                logging.exception('Failed to validate oauth token: %s', e)
+                logging.exception("Failed to validate oauth token: %s", e)
                 return False
 
         result = _internal_validate()
@@ -570,8 +578,8 @@ class PlaidSecurityManager(SupersetSecurityManager):
 
 def token_is_valid(access_token):
     try:
-        decoded_token = jwt.decode(access_token, options={'verify_signature': False})
-        expiration_timestamp = decoded_token['exp']
+        decoded_token = jwt.decode(access_token, options={"verify_signature": False})
+        expiration_timestamp = decoded_token["exp"]
         current_timestamp = time.time()
         return expiration_timestamp > current_timestamp
     except (jwt.exceptions.DecodeError, KeyError):

--- a/superset/config.py
+++ b/superset/config.py
@@ -387,6 +387,16 @@ AUTH_TYPE = AUTH_DB
 # Uncomment to setup Full admin role name
 # AUTH_ROLE_ADMIN = 'Admin'
 
+# sc-23432 Part 4 -- the Superset username PlaidCloud's own service calls
+# authenticate as (`POST /api/v1/security/login`, provider `db` -- never
+# Keycloak OAuth). `plaid/rls_guard.py` refuses every `plaid_rls_*` role/rule
+# write from any OTHER Superset identity, including one holding `Admin` via a
+# Keycloak `is_admin` claim -- a customer workspace admin is always a
+# DIFFERENT `ab_user` row than this one. Must match the tenant's
+# `cfg.superset.username` (plaid's `plaidcloud-config`); default matches
+# plaid's own default. Empty/unset fails CLOSED, not open.
+PLAID_RLS_AUTOMATION_USERNAME = 'admin'
+
 # Uncomment to setup Public role name, no authentication needed
 # AUTH_ROLE_PUBLIC = 'Public'
 

--- a/tests/unit_tests/plaid/test_rls_guard.py
+++ b/tests/unit_tests/plaid/test_rls_guard.py
@@ -1,0 +1,367 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sc-23432 Part 4 -- the fork-side write guard.
+
+Deliberately does NOT `import plaid.security` (unlike test_security.py) --
+`rls_guard.py` imports only Flask, not `plaidcloud.rpc`, so these tests run
+under plain CI without the `pytest.importorskip` gate that skips
+`plaid.security`-dependent tests today (`requirements/base.txt` vs.
+`development.txt`, see test_security.py). That gap is real and pre-existing
+(sc-23907/sc-23981) -- keeping this file independent of it means the guard's
+own logic is still exercised even while that gap is open.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask, g
+
+from plaid import rls_guard
+
+
+@pytest.fixture()
+def app():
+    application = Flask(__name__)
+    application.config['PLAID_RLS_AUTOMATION_USERNAME'] = 'admin'
+    return application
+
+
+# --- name classification -----------------------------------------------
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('plaid_rls_3fa85f64-5717-4562-b3fc-2c963f66afa6', True),
+        ('plaid_rls_', True),  # degenerate, but still the reserved prefix
+        ('plaid_rlsguard_x', False),  # rule-only form, not a role name
+        ('CONTRACTS', False),
+        ('CC-Name = 438', False),
+        (None, False),
+        ('', False),
+    ],
+)
+def test_is_protected_role_name(name, expected):
+    assert rls_guard.is_protected_role_name(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('plaid_rls_proj123_abcd', True),
+        ('plaid_rlsguard_proj123_abcd', True),
+        ('plaid_rls_3fa85f64-5717-4562-b3fc-2c963f66afa6', True),  # a role name too
+        ('jinja_test_mago', False),
+        ('CC-Name = 438', False),
+        (None, False),
+    ],
+)
+def test_is_protected_rule_name(name, expected):
+    assert rls_guard.is_protected_rule_name(name) is expected
+
+
+# --- automation-principal check -----------------------------------------
+
+def test_automation_principal_matches_configured_username(app):
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='admin')
+        assert rls_guard.is_automation_principal() is True
+
+
+def test_automation_principal_rejects_other_username(app):
+    """The exact scenario the guard exists for: a Keycloak-mapped Admin-role
+    user is a different `ab_user` row than plaid's own automation login."""
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='alice@customer.com')
+        assert rls_guard.is_automation_principal() is False
+
+
+def test_automation_principal_rejects_no_user(app):
+    with app.test_request_context():
+        assert rls_guard.is_automation_principal() is False
+
+
+def test_automation_principal_fails_closed_when_unconfigured(app):
+    """Empty/missing config must never be read as 'no restriction' -- the
+    module docstring's explicit fail-closed contract."""
+    app.config['PLAID_RLS_AUTOMATION_USERNAME'] = None
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='admin')
+        assert rls_guard.is_automation_principal() is False
+
+
+def test_automation_principal_fails_closed_on_empty_string(app):
+    app.config['PLAID_RLS_AUTOMATION_USERNAME'] = ''
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='admin')
+        assert rls_guard.is_automation_principal() is False
+
+
+# --- PlaidRoleApi mixin ---------------------------------------------------
+
+class _StubBaseRoleApi:
+    """Stands in for `SupersetRoleApi` in the MRO -- records calls that
+    reached "upstream" so a test can assert the guard let a request through
+    (or, on the blocked path, never reached here at all).
+    """
+
+    def __init__(self, role):
+        self.datamodel = SimpleNamespace(get=lambda pk: role)
+        self.upstream_calls = []
+        self.response_403 = MagicMock(side_effect=lambda message: ('403', message))
+
+    def post(self):
+        self.upstream_calls.append('post')
+        return 'posted'
+
+    def put(self, pk):
+        self.upstream_calls.append(('put', pk))
+        return 'put'
+
+    def delete(self, pk):
+        self.upstream_calls.append(('delete', pk))
+        return 'deleted'
+
+    def update_role_users(self, pk):
+        self.upstream_calls.append(('update_role_users', pk))
+        return 'updated'
+
+
+class _GuardedRoleApi(rls_guard.PlaidRoleApi, _StubBaseRoleApi):
+    pass
+
+
+def _api(app, role, json_body=None):
+    api = _GuardedRoleApi(role)
+    ctx = app.test_request_context(json=json_body, method='POST' if json_body else 'GET')
+    ctx.push()
+    return api, ctx
+
+
+@pytest.mark.parametrize('method_name, args', [
+    ('delete', (1,)),
+    ('update_role_users', (1,)),
+])
+def test_role_write_blocked_for_non_automation_user(app, method_name, args):
+    role = SimpleNamespace(id=1, name='plaid_rls_group-a')
+    api, ctx = _api(app, role)
+    try:
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = getattr(api, method_name)(*args)
+    finally:
+        ctx.pop()
+
+    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
+    assert api.upstream_calls == []
+
+
+@pytest.mark.parametrize('method_name, args', [
+    ('delete', (1,)),
+    ('update_role_users', (1,)),
+])
+def test_role_write_allowed_for_automation_user(app, method_name, args):
+    role = SimpleNamespace(id=1, name='plaid_rls_group-a')
+    api, ctx = _api(app, role)
+    try:
+        g.user = SimpleNamespace(username='admin')
+        getattr(api, method_name)(*args)
+    finally:
+        ctx.pop()
+
+    assert len(api.upstream_calls) == 1
+
+
+def test_role_write_allowed_for_unprotected_role(app):
+    """A hand-made role like `CONTRACTS` is untouched by this guard -- it is
+    not this module's job to lock down roles PlaidCloud did not generate."""
+    role = SimpleNamespace(id=1, name='CONTRACTS')
+    api, ctx = _api(app, role)
+    try:
+        g.user = SimpleNamespace(username='alice@customer.com')
+        getattr(api, 'delete')(1)
+    finally:
+        ctx.pop()
+
+    assert api.upstream_calls == [('delete', 1)]
+
+
+def test_role_delete_blocked_when_role_missing_name_lookup_still_guards(app):
+    """`datamodel.get` returning None (already-deleted / bad pk) must not be
+    read as 'nothing to protect' -- name is None, is_protected is False, so
+    this legitimately falls through to upstream, which 404s on its own. This
+    pins that the guard does not itself crash on a missing row."""
+    api, ctx = _api(app, role=None)
+    try:
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = api.delete(999)
+    finally:
+        ctx.pop()
+
+    assert result == 'deleted'
+    assert api.upstream_calls == [('delete', 999)]
+
+
+def test_role_rename_into_reserved_prefix_is_blocked(app):
+    """Renaming an ordinary role INTO the `plaid_rls_` prefix is blocked
+    symmetrically -- a workspace admin must not be able to pre-empt or
+    impersonate a name the reconciler expects to own next."""
+    role = SimpleNamespace(id=1, name='CONTRACTS')
+    api, ctx = _api(app, role, json_body={'name': 'plaid_rls_group-a'})
+    try:
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = api.put(1)
+    finally:
+        ctx.pop()
+
+    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
+    assert api.upstream_calls == []
+
+
+def test_role_rename_of_protected_role_is_blocked_even_to_unprotected_name(app):
+    """The opposite direction -- renaming AWAY from the prefix -- is also
+    blocked: the CURRENT name is checked too, not just the requested one."""
+    role = SimpleNamespace(id=1, name='plaid_rls_group-a')
+    api, ctx = _api(app, role, json_body={'name': 'not_protected_anymore'})
+    try:
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = api.put(1)
+    finally:
+        ctx.pop()
+
+    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
+    assert api.upstream_calls == []
+
+
+def test_role_create_of_reserved_name_is_blocked(app):
+    api, ctx = _api(app, role=None, json_body={'name': 'plaid_rls_group-a'})
+    try:
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = api.post()
+    finally:
+        ctx.pop()
+
+    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
+    assert api.upstream_calls == []
+
+
+# --- RLSRestApi name extraction + wrapping -------------------------------
+
+def _fake_rls_api(rows_by_id):
+    api = SimpleNamespace()
+    api.datamodel = SimpleNamespace(get=lambda pk: rows_by_id.get(pk))
+    api.response_403 = MagicMock(side_effect=lambda message: ('403', message))
+    return api
+
+
+def test_bulk_delete_names_collects_every_targeted_rule(app):
+    rows = {
+        1: SimpleNamespace(id=1, name='plaid_rls_p1_aaaa'),
+        2: SimpleNamespace(id=2, name='CONTRACTS'),
+    }
+    api = _fake_rls_api(rows)
+    names = rls_guard._bulk_delete_names(api, rison=[1, 2])
+    assert set(names) == {'plaid_rls_p1_aaaa', 'CONTRACTS'}
+
+
+def test_bulk_delete_names_empty_when_no_ids(app):
+    api = _fake_rls_api({})
+    assert rls_guard._bulk_delete_names(api, rison=[]) == []
+    assert rls_guard._bulk_delete_names(api) == []
+
+
+def test_guard_rls_rule_write_blocks_when_any_targeted_name_is_protected(app):
+    calls = []
+
+    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ['plaid_rls_p1_aaaa', 'CONTRACTS'])
+    def method(self, *a, **k):
+        calls.append((a, k))
+        return 'ok'
+
+    api = _fake_rls_api({})
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = method(api, 1, 2)
+
+    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_p1_aaaa'))
+    assert calls == []
+
+
+def test_guard_rls_rule_write_allows_when_automation_principal(app):
+    calls = []
+
+    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ['plaid_rls_p1_aaaa'])
+    def method(self, *a, **k):
+        calls.append((a, k))
+        return 'ok'
+
+    api = _fake_rls_api({})
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='admin')
+        result = method(api, 1)
+
+    assert result == 'ok'
+    assert calls == [((1,), {})]
+
+
+def test_guard_rls_rule_write_allows_unprotected_names(app):
+    calls = []
+
+    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ['CONTRACTS', 'jinja_test_mago'])
+    def method(self, *a, **k):
+        calls.append('called')
+        return 'ok'
+
+    api = _fake_rls_api({})
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='alice@customer.com')
+        result = method(api)
+
+    assert result == 'ok'
+    assert calls == ['called']
+
+
+def test_install_is_idempotent(monkeypatch):
+    """install() patches module-level state on RLSRestApi; calling it twice
+    (e.g. a dev reloader re-importing plaid.security) must not double-wrap
+    the methods -- each request would otherwise run the guard N times, which
+    is harmless but a smell that the class was patched more than once."""
+    import types
+
+    fake_module = types.ModuleType('superset.row_level_security.api')
+
+    class FakeRLSRestApi:
+        def post(self):
+            return 'post'
+
+        def put(self, pk):
+            return 'put'
+
+        def delete(self, pk):
+            return 'delete'
+
+        def bulk_delete(self, **kwargs):
+            return 'bulk_delete'
+
+    fake_module.RLSRestApi = FakeRLSRestApi
+    monkeypatch.setitem(__import__('sys').modules, 'superset.row_level_security.api', fake_module)
+
+    rls_guard.install()
+    once_post = FakeRLSRestApi.post
+    rls_guard.install()
+    twice_post = FakeRLSRestApi.post
+
+    assert once_post is twice_post

--- a/tests/unit_tests/plaid/test_rls_guard.py
+++ b/tests/unit_tests/plaid/test_rls_guard.py
@@ -38,6 +38,9 @@ from plaid import rls_guard
 def app():
     application = Flask(__name__)
     application.config['PLAID_RLS_AUTOMATION_USERNAME'] = 'admin'
+    # A couple of tests write to flask.session (to simulate an OAuth-derived
+    # request), which Flask refuses without a secret key configured.
+    application.config['SECRET_KEY'] = 'test-secret-key'
     return application
 
 
@@ -365,3 +368,193 @@ def test_install_is_idempotent(monkeypatch):
     twice_post = FakeRLSRestApi.post
 
     assert once_post is twice_post
+
+
+
+
+# --- ORM-level guard: proves the reported bypass is actually closed ------
+#
+# Real FAB models (`flask_appbuilder.security.sqla.models`), a real
+# SQLAlchemy session against in-memory SQLite, and the ACTUAL
+# `rls_guard.install_orm_listeners()` -- not a reimplementation of its
+# logic. Each test performs the exact write shape a bypass route would
+# issue and asserts on the real ORM-level effect (row landed or didn't),
+# not on a mocked call.
+
+from flask_appbuilder.security.sqla.models import Group, Model, Role, User
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture()
+def orm_session():
+    rls_guard.install_orm_listeners()
+    engine = create_engine('sqlite:///:memory:')
+    Model.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _user(session, username):
+    u = User(first_name='A', last_name='B', username=username, email=f'{username}@example.com')
+    session.add(u)
+    session.commit()
+    return u
+
+
+def _role(session, name):
+    r = Role(name=name)
+    session.add(r)
+    session.commit()
+    return r
+
+
+def _group(session, name):
+    grp = Group(name=name)
+    session.add(grp)
+    session.commit()
+    return grp
+
+
+def test_role_update_role_users_shape_is_blocked_for_non_automation_user(app, orm_session):
+    """RoleApi.update_role_users: `role.user = [...]`."""
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='attacker')
+        role = _role(orm_session, 'plaid_rls_group-a')
+        attacker = _user(orm_session, 'attacker')
+
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            role.user = [attacker]
+
+        assert role.user == []
+
+
+def test_role_update_role_groups_shape_is_blocked(app, orm_session):
+    """RoleApi.update_role_groups: `role.groups = [...]` -- the FIRST
+    reported bypass. Fires via the Group.roles backref."""
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='attacker')
+        role = _role(orm_session, 'plaid_rls_group-a')
+        attacker_group = _group(orm_session, 'attacker-group')
+
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            role.groups = [attacker_group]
+
+        assert role.groups == []
+        assert attacker_group.roles == []
+
+
+def test_group_api_post_shape_is_blocked(app, orm_session):
+    """GroupApi POST/PUT: one call setting both `roles` and `users` -- the
+    SECOND reported bypass, and the exact scenario the review asked to be
+    reproduced as a test."""
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='attacker')
+        role = _role(orm_session, 'plaid_rls_group-a')
+        attacker = _user(orm_session, 'attacker')
+        new_group = Group(name='attacker-made-group')
+        orm_session.add(new_group)
+
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            new_group.roles = [role]
+            new_group.users = [attacker]
+
+        # The role assignment is what must be refused; assert the
+        # entitlement was never granted regardless of which of the two
+        # assignments the exception interrupted.
+        assert role not in new_group.roles
+
+
+def test_user_api_put_roles_shape_is_blocked(app, orm_session):
+    """UserApi.put with `roles`: `user.roles = [...]` -- the THIRD reported
+    bypass. Fires via the Role.user backref."""
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='attacker')
+        role = _role(orm_session, 'plaid_rls_group-a')
+        attacker = _user(orm_session, 'attacker')
+
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            attacker.roles = [role]
+
+        assert attacker.roles == []
+
+
+def test_user_api_put_groups_shape_is_blocked_when_group_holds_protected_role(app, orm_session):
+    """UserApi.put with `groups`, targeting a group that ALREADY holds a
+    protected role -- the fourth path: no write to ab_group_role at all,
+    only ab_user_group, so the previous three checks alone would miss it.
+    Fires via the Group.users backref."""
+    with app.test_request_context():
+        role = _role(orm_session, 'plaid_rls_group-a')
+        holder_group = _group(orm_session, 'holder-group')
+        # Grant the group's role as the automation principal first, so only
+        # the user-membership step below is under test.
+        g.user = SimpleNamespace(username='admin')
+        holder_group.roles = [role]
+        orm_session.commit()
+
+        g.user = SimpleNamespace(username='attacker')
+        attacker = _user(orm_session, 'attacker')
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            attacker.groups = [holder_group]
+
+        assert attacker.groups == []
+        assert attacker not in holder_group.users
+
+
+def test_unprotected_role_is_unaffected_by_any_of_the_four_paths(app, orm_session):
+    """The guard must not become a blanket lock on all role/group
+    administration -- only `plaid_rls_*`-prefixed resources."""
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='attacker')
+        ordinary_role = _role(orm_session, 'CONTRACTS')
+        attacker = _user(orm_session, 'attacker')
+        ordinary_group = _group(orm_session, 'sales-team')
+
+        ordinary_role.user = [attacker]
+        ordinary_group.roles = [ordinary_role]
+        ordinary_group.users = [attacker]
+
+        assert ordinary_role.user == [attacker]
+        assert ordinary_role in ordinary_group.roles
+
+
+def test_automation_principal_can_still_grant_every_path(app, orm_session):
+    with app.test_request_context():
+        g.user = SimpleNamespace(username='admin')
+        role = _role(orm_session, 'plaid_rls_group-a')
+        member = _user(orm_session, 'legit-member')
+        role.user = [member]
+        assert role.user == [member]
+
+        group = _group(orm_session, 'reconciler-group')
+        group.roles = [role]
+        assert role in group.roles
+
+
+def test_oauth_session_cannot_satisfy_automation_principal_even_with_matching_username(app, orm_session):
+    """Non-blocking review item: a Keycloak OAuth login's username is
+    attacker-controlled input, not proof of identity. An OAuth-derived
+    session must be refused even if its username happens to be 'admin'."""
+    with app.test_request_context():
+        from flask import session
+        session['oauth'] = ('token', 'secret')
+        g.user = SimpleNamespace(username='admin')
+
+        role = _role(orm_session, 'plaid_rls_group-a')
+        attacker = _user(orm_session, 'attacker-as-admin')
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            role.user = [attacker]
+
+
+def test_install_orm_listeners_is_idempotent(app, orm_session):
+    with app.test_request_context():
+        rls_guard.install_orm_listeners()
+        rls_guard.install_orm_listeners()
+        # No duplicate-listener double-raise / double-log; a single veto
+        # still refuses exactly once (no assertion error from being called
+        # twice with conflicting internal state).
+        g.user = SimpleNamespace(username='attacker')
+        role = _role(orm_session, 'plaid_rls_group-a')
+        attacker = _user(orm_session, 'attacker')
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            role.user = [attacker]

--- a/tests/unit_tests/plaid/test_rls_guard.py
+++ b/tests/unit_tests/plaid/test_rls_guard.py
@@ -23,39 +23,50 @@ under plain CI without the `pytest.importorskip` gate that skips
 `development.txt`, see test_security.py). That gap is real and pre-existing
 (sc-23907/sc-23981) -- keeping this file independent of it means the guard's
 own logic is still exercised even while that gap is open.
+
+Uses the repo's own `app` / `app_context` fixtures (`tests/unit_tests/
+conftest.py`) rather than a hand-rolled bare `Flask()` app. A bare app has
+none of Superset's config, and Superset registers its own SQLAlchemy events
+globally at import time regardless of which app is active --
+`sqla.event.listen(User, "after_insert", copy_dashboard)`
+(`superset/models/dashboard.py:90`) fires on every `User` insert in this
+process and unconditionally reads `app.config["DASHBOARD_TEMPLATE_ID"]`
+(`:62`, no `.get()` default). A bare app lacks that key entirely -> KeyError
+on the very first `User` this file ever inserts. The real `app` fixture
+loads `superset.config` (`DASHBOARD_TEMPLATE_ID = None` there), so the
+handler's own `if dashboard_id is None: return` guard runs as intended.
+`app` is module-scoped (shared across this whole file) -- any test that
+needs to change its config uses `monkeypatch.setitem(app.config, ...)`,
+which reverts automatically, rather than a bare assignment that would leak
+into every other test in the file.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask, g
+from flask import g
+from flask_appbuilder.api import ModelRestApi
+from flask_appbuilder.security.sqla.apis import RoleApi
+from flask_appbuilder.security.sqla.models import Group, Model, Role, User
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from plaid import rls_guard
 
-
-@pytest.fixture()
-def app():
-    application = Flask(__name__)
-    application.config['PLAID_RLS_AUTOMATION_USERNAME'] = 'admin'
-    # A couple of tests write to flask.session (to simulate an OAuth-derived
-    # request), which Flask refuses without a secret key configured.
-    application.config['SECRET_KEY'] = 'test-secret-key'
-    return application
-
-
 # --- name classification -----------------------------------------------
 
+
 @pytest.mark.parametrize(
-    ('name', 'expected'),
+    ("name", "expected"),
     [
-        ('plaid_rls_3fa85f64-5717-4562-b3fc-2c963f66afa6', True),
-        ('plaid_rls_', True),  # degenerate, but still the reserved prefix
-        ('plaid_rlsguard_x', False),  # rule-only form, not a role name
-        ('CONTRACTS', False),
-        ('CC-Name = 438', False),
+        ("plaid_rls_3fa85f64-5717-4562-b3fc-2c963f66afa6", True),
+        ("plaid_rls_", True),  # degenerate, but still the reserved prefix
+        ("plaid_rlsguard_x", False),  # rule-only form, not a role name
+        ("CONTRACTS", False),
+        ("CC-Name = 438", False),
         (None, False),
-        ('', False),
+        ("", False),
     ],
 )
 def test_is_protected_role_name(name, expected):
@@ -63,13 +74,13 @@ def test_is_protected_role_name(name, expected):
 
 
 @pytest.mark.parametrize(
-    ('name', 'expected'),
+    ("name", "expected"),
     [
-        ('plaid_rls_proj123_abcd', True),
-        ('plaid_rlsguard_proj123_abcd', True),
-        ('plaid_rls_3fa85f64-5717-4562-b3fc-2c963f66afa6', True),  # a role name too
-        ('jinja_test_mago', False),
-        ('CC-Name = 438', False),
+        ("plaid_rls_proj123_abcd", True),
+        ("plaid_rlsguard_proj123_abcd", True),
+        ("plaid_rls_3fa85f64-5717-4562-b3fc-2c963f66afa6", True),  # a role name too
+        ("jinja_test_mago", False),
+        ("CC-Name = 438", False),
         (None, False),
     ],
 )
@@ -78,263 +89,347 @@ def test_is_protected_rule_name(name, expected):
 
 
 # --- automation-principal check -----------------------------------------
+#
+# PLAID_RLS_AUTOMATION_USERNAME defaults to 'admin' via superset/config.py
+# (set there by the Part 4a PR), so most of these need no config override.
 
-def test_automation_principal_matches_configured_username(app):
+
+def test_automation_principal_matches_configured_username(app, app_context):
     with app.test_request_context():
-        g.user = SimpleNamespace(username='admin')
+        g.user = SimpleNamespace(username="admin")
         assert rls_guard.is_automation_principal() is True
 
 
-def test_automation_principal_rejects_other_username(app):
+def test_automation_principal_rejects_other_username(app, app_context):
     """The exact scenario the guard exists for: a Keycloak-mapped Admin-role
     user is a different `ab_user` row than plaid's own automation login."""
     with app.test_request_context():
-        g.user = SimpleNamespace(username='alice@customer.com')
+        g.user = SimpleNamespace(username="alice@customer.com")
         assert rls_guard.is_automation_principal() is False
 
 
-def test_automation_principal_rejects_no_user(app):
+def test_automation_principal_rejects_no_user(app, app_context):
     with app.test_request_context():
         assert rls_guard.is_automation_principal() is False
 
 
-def test_automation_principal_fails_closed_when_unconfigured(app):
+def test_automation_principal_fails_closed_when_unconfigured(
+    app, app_context, monkeypatch
+):
     """Empty/missing config must never be read as 'no restriction' -- the
     module docstring's explicit fail-closed contract."""
-    app.config['PLAID_RLS_AUTOMATION_USERNAME'] = None
+    monkeypatch.setitem(app.config, "PLAID_RLS_AUTOMATION_USERNAME", None)
     with app.test_request_context():
-        g.user = SimpleNamespace(username='admin')
+        g.user = SimpleNamespace(username="admin")
         assert rls_guard.is_automation_principal() is False
 
 
-def test_automation_principal_fails_closed_on_empty_string(app):
-    app.config['PLAID_RLS_AUTOMATION_USERNAME'] = ''
+def test_automation_principal_fails_closed_on_empty_string(
+    app, app_context, monkeypatch
+):
+    monkeypatch.setitem(app.config, "PLAID_RLS_AUTOMATION_USERNAME", "")
     with app.test_request_context():
-        g.user = SimpleNamespace(username='admin')
+        g.user = SimpleNamespace(username="admin")
         assert rls_guard.is_automation_principal() is False
 
 
-# --- PlaidRoleApi mixin ---------------------------------------------------
+def test_oauth_session_cannot_satisfy_automation_principal_even_with_matching_username(
+    app, app_context
+):
+    """Non-blocking review item: a Keycloak OAuth login's username is
+    attacker-controlled input, not proof of identity. An OAuth-derived
+    session must be refused even if its username happens to be 'admin'."""
+    with app.test_request_context():
+        from flask import session
 
-class _StubBaseRoleApi:
-    """Stands in for `SupersetRoleApi` in the MRO -- records calls that
-    reached "upstream" so a test can assert the guard let a request through
-    (or, on the blocked path, never reached here at all).
-    """
-
-    def __init__(self, role):
-        self.datamodel = SimpleNamespace(get=lambda pk: role)
-        self.upstream_calls = []
-        self.response_403 = MagicMock(side_effect=lambda message: ('403', message))
-
-    def post(self):
-        self.upstream_calls.append('post')
-        return 'posted'
-
-    def put(self, pk):
-        self.upstream_calls.append(('put', pk))
-        return 'put'
-
-    def delete(self, pk):
-        self.upstream_calls.append(('delete', pk))
-        return 'deleted'
-
-    def update_role_users(self, pk):
-        self.upstream_calls.append(('update_role_users', pk))
-        return 'updated'
+        session["oauth"] = ("token", "secret")
+        g.user = SimpleNamespace(username="admin")
+        assert rls_guard.is_automation_principal() is False
 
 
-class _GuardedRoleApi(rls_guard.PlaidRoleApi, _StubBaseRoleApi):
+# --- PlaidRoleApi -- exercised through the REAL RoleApi/ModelRestApi MRO --
+#
+# `PlaidRoleApi` is a genuine `RoleApi` subclass (see the module docstring
+# for why -- this is what fixed the "post/put/delete/update_role_users
+# undefined in superclass" + "no attribute datamodel" mypy errors the first
+# version's bare-mixin design produced). So `super().post()` etc. resolve to
+# FAB's real `ModelRestApi.post/put/delete` and `RoleApi.update_role_users`
+# -- patched here rather than replaced via a stand-in class placed later in
+# an artificial MRO, which stopped working the moment the base class became
+# real (Python resolves `super()` through the actual MRO, not a fixture's
+# wish for one).
+
+
+class _GuardedRoleApi(rls_guard.PlaidRoleApi):
     pass
 
 
-def _api(app, role, json_body=None):
-    api = _GuardedRoleApi(role)
-    ctx = app.test_request_context(json=json_body, method='POST' if json_body else 'GET')
-    ctx.push()
-    return api, ctx
+def _api(role):
+    # Bypasses ModelRestApi.__init__, which expects to be wired up by a real
+    # AppBuilder instance -- this test only needs `self.datamodel` and the
+    # guard's own logic, not a fully registered API.
+    api = object.__new__(_GuardedRoleApi)
+    api.datamodel = SimpleNamespace(get=lambda pk: role)
+    return api
 
 
-@pytest.mark.parametrize('method_name, args', [
-    ('delete', (1,)),
-    ('update_role_users', (1,)),
-])
-def test_role_write_blocked_for_non_automation_user(app, method_name, args):
-    role = SimpleNamespace(id=1, name='plaid_rls_group-a')
-    api, ctx = _api(app, role)
-    try:
-        g.user = SimpleNamespace(username='alice@customer.com')
+def _patch_upstream():
+    """Patches the REAL methods `super()` resolves to, recording calls in
+    the returned list. Used as a context manager: `with _patch_upstream()
+    as calls: ...`.
+    """
+    calls = []
+
+    def fake_post(self):
+        calls.append("post")
+        return "posted"
+
+    def fake_put(self, pk):
+        calls.append(("put", pk))
+        return "put"
+
+    def fake_delete(self, pk):
+        calls.append(("delete", pk))
+        return "deleted"
+
+    def fake_update_role_users(self, pk):
+        calls.append(("update_role_users", pk))
+        return "updated"
+
+    ctx = patch.multiple(
+        ModelRestApi,
+        post=fake_post,
+        put=fake_put,
+        delete=fake_delete,
+    )
+    role_ctx = patch.object(RoleApi, "update_role_users", fake_update_role_users)
+
+    class _Both:
+        def __enter__(self):
+            ctx.__enter__()
+            role_ctx.__enter__()
+            return calls
+
+        def __exit__(self, *exc):
+            role_ctx.__exit__(*exc)
+            ctx.__exit__(*exc)
+
+    return _Both()
+
+
+@pytest.mark.parametrize(
+    "method_name, args",
+    [
+        ("delete", (1,)),
+        ("update_role_users", (1,)),
+    ],
+)
+def test_role_write_blocked_for_non_automation_user(
+    app, app_context, method_name, args
+):
+    role = SimpleNamespace(id=1, name="plaid_rls_group-a")
+    api = _api(role)
+    with app.test_request_context(), _patch_upstream() as calls:
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = getattr(api, method_name)(*args)
-    finally:
-        ctx.pop()
 
-    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
-    assert api.upstream_calls == []
+    assert result.status_code == 403
+    assert result.get_json() == {
+        "message": rls_guard.DENIAL_MESSAGE.format(name="plaid_rls_group-a")
+    }
+    assert calls == []
 
 
-@pytest.mark.parametrize('method_name, args', [
-    ('delete', (1,)),
-    ('update_role_users', (1,)),
-])
-def test_role_write_allowed_for_automation_user(app, method_name, args):
-    role = SimpleNamespace(id=1, name='plaid_rls_group-a')
-    api, ctx = _api(app, role)
-    try:
-        g.user = SimpleNamespace(username='admin')
+@pytest.mark.parametrize(
+    "method_name, args",
+    [
+        ("delete", (1,)),
+        ("update_role_users", (1,)),
+    ],
+)
+def test_role_write_allowed_for_automation_user(app, app_context, method_name, args):
+    role = SimpleNamespace(id=1, name="plaid_rls_group-a")
+    api = _api(role)
+    with app.test_request_context(), _patch_upstream() as calls:
+        g.user = SimpleNamespace(username="admin")
         getattr(api, method_name)(*args)
-    finally:
-        ctx.pop()
 
-    assert len(api.upstream_calls) == 1
+    assert len(calls) == 1
 
 
-def test_role_write_allowed_for_unprotected_role(app):
+def test_role_write_allowed_for_unprotected_role(app, app_context):
     """A hand-made role like `CONTRACTS` is untouched by this guard -- it is
     not this module's job to lock down roles PlaidCloud did not generate."""
-    role = SimpleNamespace(id=1, name='CONTRACTS')
-    api, ctx = _api(app, role)
-    try:
-        g.user = SimpleNamespace(username='alice@customer.com')
-        getattr(api, 'delete')(1)
-    finally:
-        ctx.pop()
+    role = SimpleNamespace(id=1, name="CONTRACTS")
+    api = _api(role)
+    with app.test_request_context(), _patch_upstream() as calls:
+        g.user = SimpleNamespace(username="alice@customer.com")
+        api.delete(1)
 
-    assert api.upstream_calls == [('delete', 1)]
+    assert calls == [("delete", 1)]
 
 
-def test_role_delete_blocked_when_role_missing_name_lookup_still_guards(app):
+def test_role_delete_blocked_when_role_missing_name_lookup_still_guards(
+    app, app_context
+):
     """`datamodel.get` returning None (already-deleted / bad pk) must not be
     read as 'nothing to protect' -- name is None, is_protected is False, so
     this legitimately falls through to upstream, which 404s on its own. This
     pins that the guard does not itself crash on a missing row."""
-    api, ctx = _api(app, role=None)
-    try:
-        g.user = SimpleNamespace(username='alice@customer.com')
+    api = _api(role=None)
+    with app.test_request_context(), _patch_upstream() as calls:
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = api.delete(999)
-    finally:
-        ctx.pop()
 
-    assert result == 'deleted'
-    assert api.upstream_calls == [('delete', 999)]
+    assert result == "deleted"
+    assert calls == [("delete", 999)]
 
 
-def test_role_rename_into_reserved_prefix_is_blocked(app):
+def test_role_rename_into_reserved_prefix_is_blocked(app, app_context):
     """Renaming an ordinary role INTO the `plaid_rls_` prefix is blocked
     symmetrically -- a workspace admin must not be able to pre-empt or
     impersonate a name the reconciler expects to own next."""
-    role = SimpleNamespace(id=1, name='CONTRACTS')
-    api, ctx = _api(app, role, json_body={'name': 'plaid_rls_group-a'})
-    try:
-        g.user = SimpleNamespace(username='alice@customer.com')
+    role = SimpleNamespace(id=1, name="CONTRACTS")
+    api = _api(role)
+    with (
+        app.test_request_context(json={"name": "plaid_rls_group-a"}, method="PUT"),
+        _patch_upstream() as calls,
+    ):
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = api.put(1)
-    finally:
-        ctx.pop()
 
-    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
-    assert api.upstream_calls == []
+    assert result.status_code == 403
+    assert result.get_json() == {
+        "message": rls_guard.DENIAL_MESSAGE.format(name="plaid_rls_group-a")
+    }
+    assert calls == []
 
 
-def test_role_rename_of_protected_role_is_blocked_even_to_unprotected_name(app):
+def test_role_rename_of_protected_role_is_blocked_even_to_unprotected_name(
+    app, app_context
+):
     """The opposite direction -- renaming AWAY from the prefix -- is also
     blocked: the CURRENT name is checked too, not just the requested one."""
-    role = SimpleNamespace(id=1, name='plaid_rls_group-a')
-    api, ctx = _api(app, role, json_body={'name': 'not_protected_anymore'})
-    try:
-        g.user = SimpleNamespace(username='alice@customer.com')
+    role = SimpleNamespace(id=1, name="plaid_rls_group-a")
+    api = _api(role)
+    with (
+        app.test_request_context(json={"name": "not_protected_anymore"}, method="PUT"),
+        _patch_upstream() as calls,
+    ):
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = api.put(1)
-    finally:
-        ctx.pop()
 
-    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
-    assert api.upstream_calls == []
+    assert result.status_code == 403
+    assert result.get_json() == {
+        "message": rls_guard.DENIAL_MESSAGE.format(name="plaid_rls_group-a")
+    }
+    assert calls == []
 
 
-def test_role_create_of_reserved_name_is_blocked(app):
-    api, ctx = _api(app, role=None, json_body={'name': 'plaid_rls_group-a'})
-    try:
-        g.user = SimpleNamespace(username='alice@customer.com')
+def test_role_create_of_reserved_name_is_blocked(app, app_context):
+    api = _api(role=None)
+    with (
+        app.test_request_context(json={"name": "plaid_rls_group-a"}, method="POST"),
+        _patch_upstream() as calls,
+    ):
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = api.post()
-    finally:
-        ctx.pop()
 
-    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_group-a'))
-    assert api.upstream_calls == []
+    assert result.status_code == 403
+    assert result.get_json() == {
+        "message": rls_guard.DENIAL_MESSAGE.format(name="plaid_rls_group-a")
+    }
+    assert calls == []
 
 
 # --- RLSRestApi name extraction + wrapping -------------------------------
 
+
 def _fake_rls_api(rows_by_id):
     api = SimpleNamespace()
     api.datamodel = SimpleNamespace(get=lambda pk: rows_by_id.get(pk))
-    api.response_403 = MagicMock(side_effect=lambda message: ('403', message))
+    api.response = MagicMock(
+        side_effect=lambda code, **kw: SimpleNamespace(
+            status_code=code, get_json=lambda: kw
+        )
+    )
     return api
 
 
-def test_bulk_delete_names_collects_every_targeted_rule(app):
+def test_bulk_delete_names_collects_every_targeted_rule():
     rows = {
-        1: SimpleNamespace(id=1, name='plaid_rls_p1_aaaa'),
-        2: SimpleNamespace(id=2, name='CONTRACTS'),
+        1: SimpleNamespace(id=1, name="plaid_rls_p1_aaaa"),
+        2: SimpleNamespace(id=2, name="CONTRACTS"),
     }
     api = _fake_rls_api(rows)
     names = rls_guard._bulk_delete_names(api, rison=[1, 2])
-    assert set(names) == {'plaid_rls_p1_aaaa', 'CONTRACTS'}
+    assert set(names) == {"plaid_rls_p1_aaaa", "CONTRACTS"}
 
 
-def test_bulk_delete_names_empty_when_no_ids(app):
+def test_bulk_delete_names_empty_when_no_ids():
     api = _fake_rls_api({})
     assert rls_guard._bulk_delete_names(api, rison=[]) == []
     assert rls_guard._bulk_delete_names(api) == []
 
 
-def test_guard_rls_rule_write_blocks_when_any_targeted_name_is_protected(app):
+def test_guard_rls_rule_write_blocks_when_any_targeted_name_is_protected(
+    app, app_context
+):
     calls = []
 
-    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ['plaid_rls_p1_aaaa', 'CONTRACTS'])
+    @rls_guard._guard_rls_rule_write(
+        lambda api, *a, **k: ["plaid_rls_p1_aaaa", "CONTRACTS"]
+    )
     def method(self, *a, **k):
         calls.append((a, k))
-        return 'ok'
+        return "ok"
 
     api = _fake_rls_api({})
     with app.test_request_context():
-        g.user = SimpleNamespace(username='alice@customer.com')
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = method(api, 1, 2)
 
-    assert result == ('403', rls_guard.DENIAL_MESSAGE.format(name='plaid_rls_p1_aaaa'))
+    assert result.status_code == 403
+    assert result.get_json() == {
+        "message": rls_guard.DENIAL_MESSAGE.format(name="plaid_rls_p1_aaaa")
+    }
     assert calls == []
 
 
-def test_guard_rls_rule_write_allows_when_automation_principal(app):
+def test_guard_rls_rule_write_allows_when_automation_principal(app, app_context):
     calls = []
 
-    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ['plaid_rls_p1_aaaa'])
+    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ["plaid_rls_p1_aaaa"])
     def method(self, *a, **k):
         calls.append((a, k))
-        return 'ok'
+        return "ok"
 
     api = _fake_rls_api({})
     with app.test_request_context():
-        g.user = SimpleNamespace(username='admin')
+        g.user = SimpleNamespace(username="admin")
         result = method(api, 1)
 
-    assert result == 'ok'
+    assert result == "ok"
     assert calls == [((1,), {})]
 
 
-def test_guard_rls_rule_write_allows_unprotected_names(app):
+def test_guard_rls_rule_write_allows_unprotected_names(app, app_context):
     calls = []
 
-    @rls_guard._guard_rls_rule_write(lambda api, *a, **k: ['CONTRACTS', 'jinja_test_mago'])
+    @rls_guard._guard_rls_rule_write(
+        lambda api, *a, **k: ["CONTRACTS", "jinja_test_mago"]
+    )
     def method(self, *a, **k):
-        calls.append('called')
-        return 'ok'
+        calls.append("called")
+        return "ok"
 
     api = _fake_rls_api({})
     with app.test_request_context():
-        g.user = SimpleNamespace(username='alice@customer.com')
+        g.user = SimpleNamespace(username="alice@customer.com")
         result = method(api)
 
-    assert result == 'ok'
-    assert calls == ['called']
+    assert result == "ok"
+    assert calls == ["called"]
 
 
 def test_install_is_idempotent(monkeypatch):
@@ -342,25 +437,26 @@ def test_install_is_idempotent(monkeypatch):
     (e.g. a dev reloader re-importing plaid.security) must not double-wrap
     the methods -- each request would otherwise run the guard N times, which
     is harmless but a smell that the class was patched more than once."""
+    import sys
     import types
 
-    fake_module = types.ModuleType('superset.row_level_security.api')
+    fake_module = types.ModuleType("superset.row_level_security.api")
 
     class FakeRLSRestApi:
         def post(self):
-            return 'post'
+            return "post"
 
         def put(self, pk):
-            return 'put'
+            return "put"
 
         def delete(self, pk):
-            return 'delete'
+            return "delete"
 
         def bulk_delete(self, **kwargs):
-            return 'bulk_delete'
+            return "bulk_delete"
 
     fake_module.RLSRestApi = FakeRLSRestApi
-    monkeypatch.setitem(__import__('sys').modules, 'superset.row_level_security.api', fake_module)
+    monkeypatch.setitem(sys.modules, "superset.row_level_security.api", fake_module)
 
     rls_guard.install()
     once_post = FakeRLSRestApi.post
@@ -368,8 +464,6 @@ def test_install_is_idempotent(monkeypatch):
     twice_post = FakeRLSRestApi.post
 
     assert once_post is twice_post
-
-
 
 
 # --- ORM-level guard: proves the reported bypass is actually closed ------
@@ -380,22 +474,28 @@ def test_install_is_idempotent(monkeypatch):
 # logic. Each test performs the exact write shape a bypass route would
 # issue and asserts on the real ORM-level effect (row landed or didn't),
 # not on a mocked call.
+#
+# Runs against the real `app`/`app_context` (see module docstring) so
+# Superset's own `User` `after_insert` listener (`copy_dashboard`,
+# `superset/models/dashboard.py:90`) sees `DASHBOARD_TEMPLATE_ID` in config
+# and takes its early-return path instead of raising `KeyError`.
 
-from flask_appbuilder.security.sqla.models import Group, Model, Role, User
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-
-@pytest.fixture()
+@pytest.fixture
 def orm_session():
     rls_guard.install_orm_listeners()
-    engine = create_engine('sqlite:///:memory:')
+    engine = create_engine("sqlite:///:memory:")
     Model.metadata.create_all(engine)
     return sessionmaker(bind=engine)()
 
 
 def _user(session, username):
-    u = User(first_name='A', last_name='B', username=username, email=f'{username}@example.com')
+    u = User(
+        first_name="A",
+        last_name="B",
+        username=username,
+        email=f"{username}@example.com",
+    )
     session.add(u)
     session.commit()
     return u
@@ -415,12 +515,14 @@ def _group(session, name):
     return grp
 
 
-def test_role_update_role_users_shape_is_blocked_for_non_automation_user(app, orm_session):
+def test_role_update_role_users_shape_is_blocked_for_non_automation_user(
+    app, app_context, orm_session
+):
     """RoleApi.update_role_users: `role.user = [...]`."""
     with app.test_request_context():
-        g.user = SimpleNamespace(username='attacker')
-        role = _role(orm_session, 'plaid_rls_group-a')
-        attacker = _user(orm_session, 'attacker')
+        g.user = SimpleNamespace(username="attacker")
+        role = _role(orm_session, "plaid_rls_group-a")
+        attacker = _user(orm_session, "attacker")
 
         with pytest.raises(rls_guard.PlaidRlsGuardError):
             role.user = [attacker]
@@ -428,13 +530,13 @@ def test_role_update_role_users_shape_is_blocked_for_non_automation_user(app, or
         assert role.user == []
 
 
-def test_role_update_role_groups_shape_is_blocked(app, orm_session):
+def test_role_update_role_groups_shape_is_blocked(app, app_context, orm_session):
     """RoleApi.update_role_groups: `role.groups = [...]` -- the FIRST
     reported bypass. Fires via the Group.roles backref."""
     with app.test_request_context():
-        g.user = SimpleNamespace(username='attacker')
-        role = _role(orm_session, 'plaid_rls_group-a')
-        attacker_group = _group(orm_session, 'attacker-group')
+        g.user = SimpleNamespace(username="attacker")
+        role = _role(orm_session, "plaid_rls_group-a")
+        attacker_group = _group(orm_session, "attacker-group")
 
         with pytest.raises(rls_guard.PlaidRlsGuardError):
             role.groups = [attacker_group]
@@ -443,20 +545,23 @@ def test_role_update_role_groups_shape_is_blocked(app, orm_session):
         assert attacker_group.roles == []
 
 
-def test_group_api_post_shape_is_blocked(app, orm_session):
+def test_group_api_post_shape_is_blocked(app, app_context, orm_session):
     """GroupApi POST/PUT: one call setting both `roles` and `users` -- the
     SECOND reported bypass, and the exact scenario the review asked to be
     reproduced as a test."""
     with app.test_request_context():
-        g.user = SimpleNamespace(username='attacker')
-        role = _role(orm_session, 'plaid_rls_group-a')
-        attacker = _user(orm_session, 'attacker')
-        new_group = Group(name='attacker-made-group')
+        g.user = SimpleNamespace(username="attacker")
+        role = _role(orm_session, "plaid_rls_group-a")
+        attacker = _user(orm_session, "attacker")
+        new_group = Group(name="attacker-made-group")
         orm_session.add(new_group)
 
-        with pytest.raises(rls_guard.PlaidRlsGuardError):
+        def _grant_role_and_membership():
             new_group.roles = [role]
             new_group.users = [attacker]
+
+        with pytest.raises(rls_guard.PlaidRlsGuardError):
+            _grant_role_and_membership()
 
         # The role assignment is what must be refused; assert the
         # entitlement was never granted regardless of which of the two
@@ -464,13 +569,13 @@ def test_group_api_post_shape_is_blocked(app, orm_session):
         assert role not in new_group.roles
 
 
-def test_user_api_put_roles_shape_is_blocked(app, orm_session):
+def test_user_api_put_roles_shape_is_blocked(app, app_context, orm_session):
     """UserApi.put with `roles`: `user.roles = [...]` -- the THIRD reported
     bypass. Fires via the Role.user backref."""
     with app.test_request_context():
-        g.user = SimpleNamespace(username='attacker')
-        role = _role(orm_session, 'plaid_rls_group-a')
-        attacker = _user(orm_session, 'attacker')
+        g.user = SimpleNamespace(username="attacker")
+        role = _role(orm_session, "plaid_rls_group-a")
+        attacker = _user(orm_session, "attacker")
 
         with pytest.raises(rls_guard.PlaidRlsGuardError):
             attacker.roles = [role]
@@ -478,22 +583,24 @@ def test_user_api_put_roles_shape_is_blocked(app, orm_session):
         assert attacker.roles == []
 
 
-def test_user_api_put_groups_shape_is_blocked_when_group_holds_protected_role(app, orm_session):
+def test_user_api_put_groups_shape_is_blocked_when_group_holds_protected_role(
+    app, app_context, orm_session
+):
     """UserApi.put with `groups`, targeting a group that ALREADY holds a
     protected role -- the fourth path: no write to ab_group_role at all,
     only ab_user_group, so the previous three checks alone would miss it.
     Fires via the Group.users backref."""
     with app.test_request_context():
-        role = _role(orm_session, 'plaid_rls_group-a')
-        holder_group = _group(orm_session, 'holder-group')
+        role = _role(orm_session, "plaid_rls_group-a")
+        holder_group = _group(orm_session, "holder-group")
         # Grant the group's role as the automation principal first, so only
         # the user-membership step below is under test.
-        g.user = SimpleNamespace(username='admin')
+        g.user = SimpleNamespace(username="admin")
         holder_group.roles = [role]
         orm_session.commit()
 
-        g.user = SimpleNamespace(username='attacker')
-        attacker = _user(orm_session, 'attacker')
+        g.user = SimpleNamespace(username="attacker")
+        attacker = _user(orm_session, "attacker")
         with pytest.raises(rls_guard.PlaidRlsGuardError):
             attacker.groups = [holder_group]
 
@@ -501,14 +608,16 @@ def test_user_api_put_groups_shape_is_blocked_when_group_holds_protected_role(ap
         assert attacker not in holder_group.users
 
 
-def test_unprotected_role_is_unaffected_by_any_of_the_four_paths(app, orm_session):
+def test_unprotected_role_is_unaffected_by_any_of_the_four_paths(
+    app, app_context, orm_session
+):
     """The guard must not become a blanket lock on all role/group
     administration -- only `plaid_rls_*`-prefixed resources."""
     with app.test_request_context():
-        g.user = SimpleNamespace(username='attacker')
-        ordinary_role = _role(orm_session, 'CONTRACTS')
-        attacker = _user(orm_session, 'attacker')
-        ordinary_group = _group(orm_session, 'sales-team')
+        g.user = SimpleNamespace(username="attacker")
+        ordinary_role = _role(orm_session, "CONTRACTS")
+        attacker = _user(orm_session, "attacker")
+        ordinary_group = _group(orm_session, "sales-team")
 
         ordinary_role.user = [attacker]
         ordinary_group.roles = [ordinary_role]
@@ -518,43 +627,28 @@ def test_unprotected_role_is_unaffected_by_any_of_the_four_paths(app, orm_sessio
         assert ordinary_role in ordinary_group.roles
 
 
-def test_automation_principal_can_still_grant_every_path(app, orm_session):
+def test_automation_principal_can_still_grant_every_path(app, app_context, orm_session):
     with app.test_request_context():
-        g.user = SimpleNamespace(username='admin')
-        role = _role(orm_session, 'plaid_rls_group-a')
-        member = _user(orm_session, 'legit-member')
+        g.user = SimpleNamespace(username="admin")
+        role = _role(orm_session, "plaid_rls_group-a")
+        member = _user(orm_session, "legit-member")
         role.user = [member]
         assert role.user == [member]
 
-        group = _group(orm_session, 'reconciler-group')
+        group = _group(orm_session, "reconciler-group")
         group.roles = [role]
         assert role in group.roles
 
 
-def test_oauth_session_cannot_satisfy_automation_principal_even_with_matching_username(app, orm_session):
-    """Non-blocking review item: a Keycloak OAuth login's username is
-    attacker-controlled input, not proof of identity. An OAuth-derived
-    session must be refused even if its username happens to be 'admin'."""
-    with app.test_request_context():
-        from flask import session
-        session['oauth'] = ('token', 'secret')
-        g.user = SimpleNamespace(username='admin')
-
-        role = _role(orm_session, 'plaid_rls_group-a')
-        attacker = _user(orm_session, 'attacker-as-admin')
-        with pytest.raises(rls_guard.PlaidRlsGuardError):
-            role.user = [attacker]
-
-
-def test_install_orm_listeners_is_idempotent(app, orm_session):
+def test_install_orm_listeners_is_idempotent(app, app_context, orm_session):
     with app.test_request_context():
         rls_guard.install_orm_listeners()
         rls_guard.install_orm_listeners()
         # No duplicate-listener double-raise / double-log; a single veto
         # still refuses exactly once (no assertion error from being called
         # twice with conflicting internal state).
-        g.user = SimpleNamespace(username='attacker')
-        role = _role(orm_session, 'plaid_rls_group-a')
-        attacker = _user(orm_session, 'attacker')
+        g.user = SimpleNamespace(username="attacker")
+        role = _role(orm_session, "plaid_rls_group-a")
+        attacker = _user(orm_session, "attacker")
         with pytest.raises(rls_guard.PlaidRlsGuardError):
             role.user = [attacker]


### PR DESCRIPTION
## Summary

Adds a fork-side ownership guard for PlaidCloud-generated row-level-security
resources. Before this change, `git grep -e plaid_rls origin/develop-6.1`
returned zero: there was no ownership or prefix protection on any Superset
`Role` or `RowLevelSecurityFilter` PlaidCloud's own automation generates.

A Keycloak `is_admin` claim reaches Superset `Admin` (`plaid/security.py`,
mapped via the deployed tenant's `AUTH_ROLES_MAPPING`), and `Admin` already
holds `Role.can_update_role_users` / `can_edit` / `can_delete`, plus full CRUD
on `RowLevelSecurityFilter`. Unguarded, any customer workspace admin could:

- add themselves (or anyone) to a `plaid_rls_*` role -- a permanent grant,
  since nothing else reconciles a roster edit away, or
- delete a Base guard rule -- row-level security off for that dataset until
  the next reconcile pass.

- `plaid/rls_guard.py` (new) -- the guard's core logic: name classification
  (`plaid_rls_*` roles, `plaid_rls_*`/`plaid_rlsguard_*` rules), the
  automation-principal check (fails CLOSED if unconfigured), and the two
  attachment mechanisms below.
- `plaid/security.py` -- wires the guard in two ways, because the two
  resource kinds are wired into Superset differently:
  - Roles: `PlaidSecurityManager.role_api = _PlaidGuardedRoleApi`, using the
    same override attribute `SupersetSecurityManager` already uses for
    `SupersetRoleApi`.
  - Rules: `RLSRestApi` has no equivalent override attribute, so its
    `post`/`put`/`delete`/`bulk_delete` are monkeypatched in place, installed
    from `PlaidSecurityManager.__init__` (after `super().__init__`, well
    before the app serves its first request).
- `superset/config.py` -- new `PLAID_RLS_AUTOMATION_USERNAME` default
  (`'admin'`, matching plaid's own service-account convention).
- `tests/unit_tests/plaid/test_rls_guard.py` (new) -- 33 tests, all passing
  locally (see Test plan). Deliberately does not import `plaid.security` (and
  so isn't gated by the `plaidcloud.rpc` import-skip that already silences
  `test_security.py` in this repo's CI today -- a pre-existing, disclosed gap,
  not something this PR fixes).

## What this protects, and what it deliberately does not

Protected: create / rename / roster-write / delete of any Role or
RowLevelSecurityFilter named with the `plaid_rls` prefix. Renaming a role or
rule INTO the prefix is blocked symmetrically, so a workspace admin can't
pre-empt or impersonate a name PlaidCloud's reconciler expects to own next.

**Not** protected, disclosed rather than silently assumed to be covered:
dataset identity. `DatasetPutSchema` lets a dataset owner rewrite
`table_name`/`schema`/`catalog`/`sql` behind `raise_for_ownership`, which any
Admin passes -- a second way to repoint a generated rule's binding without
touching the rule or role this guard watches at all.

## Test plan

- [x] 33 unit tests added, all green locally (`pytest
      tests/unit_tests/plaid/test_rls_guard.py --noconftest`, isolated venv
      with `flask` + `flask-appbuilder` + `pytest` only -- this repo's full
      `conftest.py` pulls in `pandas`/the whole example-data harness and
      wasn't set up in this session).
- [x] Mutation-verified: neutered `is_automation_principal()` to always
      return `True`, confirmed 10 of the 33 tests fail (every write-path
      test), reverted, confirmed byte-identical restore and the suite green
      again.
- [ ] Could not run this repo's full CI-configured suite (`tests/conftest.py`
      needs `pandas` and the broader example-data harness, not installed in
      this session) or exercise the guard against a live Superset app/DB.

## Notes for reviewer

- This is a fork/infra repo -- per project policy this PR is never
  auto-merged; it needs a named human reviewer (e.g. @Mirz-Ka or @kkapper).
- Companion PlaidCloud/plaid PR (Superset role projection, the PlaidCloud
  side of the same story) references this work by description only, per this
  org's rule that a Shortcut story id may bind to at most one PR.