### PR TITLE
fix(ci): unblock unit-tests and pre-commit baseline on develop-6.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -68,7 +68,18 @@ jobs:
         run: |
           set +e  # Don't exit immediately on failure
           export SKIP=eslint-frontend,type-checking-frontend
-          pre-commit run --all-files
+          # Scope pre-commit to the files actually touched by this change instead of
+          # `--all-files`. The fork has accumulated pre-existing pre-commit drift
+          # (formatting, i18n, mypy) across files no PR touches; running `--all-files`
+          # unconditionally means every PR inherits that baseline debt and can never
+          # gate on its own diff. This mirrors the diff-scoping the local `pylint`
+          # hook already does internally (see .pre-commit-config.yaml).
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+            pre-commit run --from-ref FETCH_HEAD --to-ref HEAD
+          else
+            pre-commit run --all-files
+          fi
           PRE_COMMIT_EXIT_CODE=$?
           git diff --quiet --exit-code
           GIT_DIFF_EXIT_CODE=$?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,15 @@ repos:
     hooks:
       - id: mypy
         name: mypy (main)
-        args: [--check-untyped-defs]
+        # --follow-imports=silent: still use imported modules for accurate type
+        # inference, but only *report* errors for the files explicitly passed
+        # to this invocation. Without it, a PR touching one file can inherit
+        # pre-existing errors from unrelated modules it merely imports (e.g.
+        # touching only superset/db_engine_specs/databend.py surfaced a
+        # pre-existing, unrelated error in superset/dashboards/permalink/api.py)
+        # -- which defeated scoping `pre-commit run` to a PR's own diff. Files
+        # passed explicitly are unaffected: their errors still surface.
+        args: [--check-untyped-defs, --follow-imports=silent]
         exclude: ^superset-extensions-cli/
         additional_dependencies: [
             types-cachetools,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,14 +250,6 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 no_implicit_optional = true
 warn_unused_ignores = true
-# Type-check imported modules for accurate inference, but only *report* errors
-# for the files explicitly passed on the command line. Without this, the
-# pre-commit `mypy` hook -- even when scoped to a PR's own diff -- surfaces
-# pre-existing errors from any module transitively imported by a touched
-# file (e.g. touching superset/db_engine_specs/databend.py alone pulls in an
-# unrelated, pre-existing error in superset/dashboards/permalink/api.py).
-# That made `pre-commit` fail identically on every PR regardless of content.
-follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 module = "superset.migrations.versions.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,14 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 no_implicit_optional = true
 warn_unused_ignores = true
+# Type-check imported modules for accurate inference, but only *report* errors
+# for the files explicitly passed on the command line. Without this, the
+# pre-commit `mypy` hook -- even when scoped to a PR's own diff -- surfaces
+# pre-existing errors from any module transitively imported by a touched
+# file (e.g. touching superset/db_engine_specs/databend.py alone pulls in an
+# unrelated, pre-existing error in superset/dashboards/permalink/api.py).
+# That made `pre-commit` fail identically on every PR regardless of content.
+follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 module = "superset.migrations.versions.*"

--- a/superset/db_engine_specs/databend.py
+++ b/superset/db_engine_specs/databend.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from typing import Any, cast, TYPE_CHECKING
 
 import sqlalchemy as sa
-from databend_sqlalchemy.databend_dialect import DatabendCompiler
 from flask_babel import gettext as __
 from marshmallow import fields, Schema
 from marshmallow.validate import Range
@@ -51,6 +50,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+try:
+    from databend_sqlalchemy.databend_dialect import DatabendCompiler
+except ImportError:
+
+    class DatabendCompiler:  # type: ignore
+        """Dummy class used when databend-sqlalchemy is not installed.
+
+        Keeps this module importable (e.g. for collection by the test suite,
+        or for ``get_available_engine_specs()``) without the optional driver
+        present. Mirrors the pattern used for the optional ``databricks``
+        driver in ``superset/db_engine_specs/databricks.py``.
+        """
+
+
 # Databend has no ILIKE operator. ``DatabendCompiler`` inherits ILIKE rendering
 # from SQLAlchemy's ``PGCompiler``, which emits the Postgres-native ``x ILIKE y``
 # that Databend rejects. Superset builds case-insensitive filters with
@@ -76,8 +89,8 @@ def _databend_visit_not_ilike_op_binary(
     return self.visit_not_like_op_binary(binary, operator, **kw)
 
 
-DatabendCompiler.visit_ilike_op_binary = _databend_visit_ilike_op_binary  # type: ignore[method-assign]
-DatabendCompiler.visit_not_ilike_op_binary = _databend_visit_not_ilike_op_binary  # type: ignore[method-assign]
+DatabendCompiler.visit_ilike_op_binary = _databend_visit_ilike_op_binary
+DatabendCompiler.visit_not_ilike_op_binary = _databend_visit_not_ilike_op_binary
 
 
 class DatabendBaseEngineSpec(BaseEngineSpec):

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -338,6 +338,14 @@ def test_database_connection(
             "id": 1,
             "impersonate_user": False,
             "is_managed_externally": False,
+            # superset/databases/api.py DatabaseRestApi.show_columns includes
+            # "sqlalchemy_uri" (fork addition, commit 5572cc91a0e, absent
+            # upstream) alongside upstream's fields. Safe to expose: the
+            # stored value never carries a password -- Database.
+            # set_sqlalchemy_uri (superset/models/core.py) explicitly strips
+            # credentials before persisting. This test was never updated for
+            # the fork addition.
+            "sqlalchemy_uri": "gsheets://",
             "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
         },
     }

--- a/tests/unit_tests/db_engine_specs/test_databend.py
+++ b/tests/unit_tests/db_engine_specs/test_databend.py
@@ -156,6 +156,13 @@ def test_make_label_compatible(column_name: str, expected_result: str) -> None:
 )
 def test_ilike_compiles_to_lower_like(build_expr: Any, expected: str) -> None:
     """Databend has no ILIKE; it must compile to LOWER(x) LIKE LOWER(y)."""
+    # Unlike the rest of this module, this test exercises the real
+    # databend_sqlalchemy dialect's compiler rather than just superset's
+    # own engine-spec code, so it needs the (optional, not installed by
+    # default -- see requirements/development.in) driver package itself.
+    # Mirrors tests/unit_tests/db_engine_specs/test_datastore.py.
+    pytest.importorskip("databend_sqlalchemy")
+
     import sqlalchemy as sa
 
     # Importing the engine spec installs the ILIKE compiler override.

--- a/tests/unit_tests/db_engine_specs/test_databend.py
+++ b/tests/unit_tests/db_engine_specs/test_databend.py
@@ -164,10 +164,10 @@ def test_ilike_compiles_to_lower_like(build_expr: Any, expected: str) -> None:
     pytest.importorskip("databend_sqlalchemy")
 
     import sqlalchemy as sa
+    from databend_sqlalchemy.databend_dialect import DatabendDialect
 
     # Importing the engine spec installs the ILIKE compiler override.
     import superset.db_engine_specs.databend  # noqa: F401
-    from databend_sqlalchemy.databend_dialect import DatabendDialect
 
     expr = build_expr(sa.column("name"))
     compiled = expr.compile(

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -300,6 +300,13 @@ def test_get_datatype_without_mysqlclient(
     Subclasses like StarRocks and Doris speak the MySQL wire protocol but ship a
     pure Python driver, so ``MySQLdb`` is not necessarily installed.
     """
+    # pymysql is the fallback this test exercises; it's an optional transitive
+    # dependency (pulled in via the `starrocks` extra, which -- like `databend`
+    # -- isn't part of requirements/development.in) and isn't installed by
+    # default. See tests/unit_tests/db_engine_specs/test_datastore.py for the
+    # same pattern with a different optional driver.
+    pytest.importorskip("pymysql")
+
     from superset.db_engine_specs.mysql import MySQLEngineSpec
 
     # ``None`` in ``sys.modules`` makes the import raise ``ImportError``

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -295,6 +295,13 @@ def test_fetch_data_without_mysqlclient(monkeypatch: pytest.MonkeyPatch) -> None
     installed; ``fetch_data`` used to fail with ``ModuleNotFoundError`` because
     it inherits ``get_datatype`` from the MySQL spec.
     """
+    # pymysql is the fallback this test exercises; it's an optional transitive
+    # dependency (pulled in via the `starrocks` extra, which -- like `databend`
+    # -- isn't part of requirements/development.in) and isn't installed by
+    # default. See tests/unit_tests/db_engine_specs/test_datastore.py for the
+    # same pattern with a different optional driver.
+    pytest.importorskip("pymysql")
+
     from superset.db_engine_specs.starrocks import StarRocksEngineSpec
 
     # ``None`` in ``sys.modules`` makes the import raise ``ImportError``

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -362,7 +362,11 @@ class TestGenerateDashboard:
                 assert chart_data["type"] == "CHART"
                 assert "meta" in chart_data
                 assert chart_data["meta"]["chartId"] == chart_id
-                assert chart_data["meta"]["width"] == 4
+                # GRID_DEFAULT_CHART_WIDTH (superset/mcp_service/dashboard/constants.py)
+                # was proportionally doubled from 4 to 8 alongside GRID_COLUMN_COUNT
+                # (12 -> 24) by 71ac9253af ("add 24 cols dashboard with migration
+                # script"); this test was never updated to match.
+                assert chart_data["meta"]["width"] == 8
 
                 chart_parents = chart_data["parents"]
                 column_key = chart_parents[-1]
@@ -1300,9 +1304,13 @@ class TestLayoutHelpers:
         assert layout[row_key]["children"] == [column_key]
         assert layout[column_key]["type"] == "COLUMN"
         assert layout[column_key]["children"] == [chart_key]
-        assert layout[column_key]["meta"]["width"] == 12
+        # GRID_COLUMN_COUNT / GRID_DEFAULT_CHART_WIDTH (superset/mcp_service/dashboard/
+        # constants.py) were proportionally doubled (12 -> 24, 4 -> 8) by 71ac9253af
+        # ("add 24 cols dashboard with migration script"); this test was never
+        # updated to match.
+        assert layout[column_key]["meta"]["width"] == 24
         assert layout[chart_key]["type"] == "CHART"
-        assert layout[chart_key]["meta"]["width"] == 4
+        assert layout[chart_key]["meta"]["width"] == 8
         assert layout[chart_key]["meta"]["chartId"] == 42
 
     def test_ensure_layout_structure_creates_missing(self):

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -33,7 +33,14 @@ def test_csrf_not_exempt(app_context: None) -> None:
         "MenuApi",
         "SecurityApi",
         "OpenApi",
-        "PermissionViewMenuApi",
+        # The fork registers SecurityManager.permission_view_menu_api =
+        # SupersetPermissionViewMenuApi (superset/security/manager.py), a
+        # subclass of FAB's PermissionViewMenuApi, to allow filtering by `id`
+        # and by related permission/view_menu name fields (sc-23044 /
+        # apache/superset#40293). FAB derives the Flask blueprint name from
+        # the runtime class name, so the registered blueprint is named after
+        # the fork's subclass, not the upstream base class.
+        "SupersetPermissionViewMenuApi",
         "SupersetRoleApi",
         "SupersetUserApi",
         "PermissionApi",


### PR DESCRIPTION
### SUMMARY

Fixes the `develop-6.1` CI baseline itself, not any one feature branch. Every open PR against `develop-6.1` (#354, #353, #343) was showing the identical `fail=27 ok=10/11` signature, meaning the base branch was broken, not the PRs.

**Root causes found (grouped):**

1. **`unit-tests` (the real blocker):** `superset/db_engine_specs/databend.py` imports `databend_sqlalchemy` unconditionally at module scope. That package is deliberately absent from `requirements/development.txt` — like every other optional engine driver (bigquery, clickhouse, databricks, etc.), it's only in `requirements/base.in` behind a `pyproject.toml` extra nothing in `development.in` enables. The resulting `ModuleNotFoundError` at collection time cascaded into ~50 failures that looked unrelated (`config_test.py`, OAuth2 tests, database/dataset API tests) — all of them were actually the same root cause surfacing through different fixtures — and hit `--maxfail=50` before a PR's own new tests ever ran.
2. **`pre-commit` (the other real blocker):** the workflow always ran `pre-commit run --all-files`, so every PR was gated on the *entire* repo's pre-commit compliance, not its own diff. The fork carries real, pre-existing drift (untranslated frontend strings, formatting) in files no open PR touches — that's a separate, much larger backlog than this PR fixes.
3. **Everything else in the 27** (cypress/playwright matrices, `test-postgres/mysql/sqlite`, `test-load-examples`, License Check, `python-dependency-liccheck`, `check-python-deps`): genuinely separate, needing infrastructure this session doesn't have (live DBs, browsers, a license server) or an unrelated dependency-drift gate. Confirmed by reading their actual job logs on this PR that neither License Check nor liccheck are caused by this change (see "Left alone" below) — left alone.

**What this PR fixes:**

- `superset/db_engine_specs/databend.py`: make the `databend_sqlalchemy` import optional with a dummy fallback class, mirroring the existing precedent for the optional `databricks.sql` driver in `superset/db_engine_specs/databricks.py`. Also drops two `# type: ignore[method-assign]` comments mypy already flags as stale.
- `tests/unit_tests/db_engine_specs/test_databend.py`: `test_ilike_compiles_to_lower_like` compiles SQL through the *real* dialect, so it genuinely needs the optional package. Guarded with `pytest.importorskip("databend_sqlalchemy")`, mirroring `tests/unit_tests/db_engine_specs/test_datastore.py`.
- `tests/unit_tests/db_engine_specs/test_mysql.py` / `test_starrocks.py`: `test_get_datatype_without_mysqlclient` / `test_fetch_data_without_mysqlclient` exercise `MySQLEngineSpec`'s fallback to `pymysql` when `MySQLdb` is absent — same shape of bug as databend. `pymysql` is an optional transitive dependency (pulled in only via the `starrocks` extra, which — like `databend` — isn't part of `requirements/development.in`) and isn't installed. Same `pytest.importorskip` fix.
- `.github/workflows/pre-commit.yml`: scope `pre-commit run` to the PR's actual diff (`--from-ref <base>...--to-ref HEAD`) instead of `--all-files`, mirroring the diff-scoping the local `pylint` hook already does internally.
- `.pre-commit-config.yaml`: added `--follow-imports=silent` to the `mypy` hook's `args:`. Diff-scoping alone isn't sufficient for mypy — by default it reports errors for every module it transitively imports, not just the files explicitly given to it, so a one-file PR can still inherit pre-existing errors from unrelated modules it happens to import. Observed concretely: scoping to only `databend.py` still surfaced a pre-existing, unrelated bug in `superset/dashboards/permalink/api.py:300`. Verified locally that this **doesn't** suppress errors in files that are actually part of a diff (only in files reached transitively) — added as a hook-level flag rather than in the shared `[tool.mypy]` in `pyproject.toml`, since that file is also read by IDEs/local runs/any future full-repo job and is upstream-maintained (avoids adding rebase-conflict surface for no reason).
- Three tests that looked like fork-vs-upstream drift were verified as drift (not bugs) and fixed:
  - `tests/unit_tests/security/api_test.py::test_csrf_not_exempt`: `superset/security/manager.py:325` registers `SecurityManager.permission_view_menu_api = SupersetPermissionViewMenuApi`, a fork subclass of FAB's `PermissionViewMenuApi` (added for sc-23044 / apache/superset#40293 filtering support). FAB derives the registered Flask blueprint's name from the runtime class name, so the real, intended blueprint is `SupersetPermissionViewMenuApi`, not upstream's `PermissionViewMenuApi`. Updated the expected set.
  - `tests/unit_tests/databases/api_test.py::test_database_connection`: `DatabaseRestApi.show_columns` in `superset/databases/api.py` includes `sqlalchemy_uri` (fork addition, git-blamed to `5572cc91a0e`; confirmed absent from upstream's current `show_columns`/`list_columns` for the same class via `gh api repos/apache/superset/contents/superset/databases/api.py`). Verified this is safe to expose, not a leak: `Database.set_sqlalchemy_uri` (`superset/models/core.py`) explicitly strips credentials before persisting — the stored value can never carry a password. The plain `GET /api/v1/database/{id}` assertion just never got the field added (the `.../connection` assertion right above it already expected it). Added it to match.
  - `tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py` (`test_generate_dashboard_many_charts`, `test_add_chart_to_layout_creates_column`): looked like a doubling defect at first (`8 == 4`, `24 == 12`) — investigated specifically to rule that out before touching anything. Commit `71ac9253af` ("add 24 cols dashboard with migration script") proportionally doubled both `GRID_DEFAULT_CHART_WIDTH` (4→8) and `GRID_COLUMN_COUNT` (12→24) in `superset/mcp_service/dashboard/constants.py`, preserving the exact same visual proportion (4/12 == 8/24) — a deliberate, correct migration. That commit touched only `constants.py`; these two tests were never updated. Updated their expected widths to the current, correct post-migration values.

**Left alone (real infra/effort, not a config fix, or genuinely unrelated to this change):**

- cypress / playwright matrices — need a live browser + running app stack.
- `test-postgres*` / `test-mysql` / `test-sqlite` / `test-load-examples` — need live databases.
- `License Check` — read the job's actual log on this PR: fails on missing Apache license headers in files this PR doesn't touch (`plaid/*.py`, several frontend plugin configs, `TEST_PLAN_BF2_6.1.md`, `devspace.yaml`). Pre-existing, unrelated.
- `python-dependency-liccheck` — read the job's actual log on this PR: fails on 5 packages already in the dependency tree before this PR (`asyncmy2`, `plaidcloud-rpc`, `psycopg2-binary`, `python-geohash`, `starrocks`) missing from the license allowlist. `databend_sqlalchemy` was never added as a dependency by this PR, so it isn't what's tripping this gate.
- `check-python-deps` — unrelated dependency-drift gate, not investigated.
- The repo-wide formatting/i18n backlog itself (hundreds of files, mostly frontend) — real, but a full remediation is a separate, much larger effort than a CI-baseline fix. Diff-scoping (this PR) means it no longer blocks PRs that don't touch those files.
- A handful of *additional* local-only failures (timezone-dependent date-parsing tests, two more `databases/api_test.py`/import tests) showed up in my macOS venv but **not** on CI's Linux runner (`unit-tests (next)` came back with exactly 6 real failures, all now fixed here) — those are environment artifacts of my local machine, not real, and are not touched.
- `pylint` hook's target-branch fallback defaults to `master` (dead for this fork) and relies on `origin/<branch>` refs the checkout step's shallow clone doesn't fetch. Currently harmless (silently no-ops instead of false-failing) but worth a follow-up so it actually lints diffs in CI.

### TESTING INSTRUCTIONS

- Real CI on this PR: `pre-commit` **SUCCESS on all three matrix legs** (current/next/previous). `unit-tests (next)` went from hitting `--maxfail=50` at 1,339 tests collected to running the full suite (**5,611 passed** before the last fix commit, with exactly the 6 failures listed above — all fixed in the final commit). Re-run pending on the final commit.
- Locally (`uv` venv, Python 3.11, installed from the exact `requirements/development.txt` CI uses, `databend_sqlalchemy`/`pymysql` deliberately **not** installed, matching CI): the 6 tests CI reported as failing all pass/skip cleanly; `pre-commit run --from-ref origin/develop-6.1 --to-ref HEAD` (real hook envs: mypy 1.15.0, ruff, pylint) exits 0 on this diff.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
