### PR TITLE
fix(sql): register a Databend sqlglot dialect (sc-23778)

### DIFF
--- a/superset/sql/dialects/__init__.py
+++ b/superset/sql/dialects/__init__.py
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .databend import Databend
 from .db2 import DB2
 from .dremio import Dremio
 from .firebolt import Firebolt, FireboltOld
 from .pinot import Pinot
 
-__all__ = ["DB2", "Dremio", "Firebolt", "FireboltOld", "Pinot"]
+__all__ = ["DB2", "Databend", "Dremio", "Firebolt", "FireboltOld", "Pinot"]

--- a/superset/sql/dialects/databend.py
+++ b/superset/sql/dialects/databend.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Databend dialect.
+
+Databend's SQL is close to ClickHouse, but it also accepts a *leading*
+``SETTINGS (...)`` clause before the statement — e.g.
+``SETTINGS (max_execute_time_in_seconds=300) SELECT ...``, which PlaidCloud
+emits as a query-timeout wrapper. No built-in sqlglot dialect parses that form,
+so it is absorbed here and re-emitted verbatim on generation.
+"""
+
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.dialects.clickhouse import ClickHouse
+from sqlglot.tokens import TokenType
+
+
+class Databend(ClickHouse):
+    class Parser(ClickHouse.Parser):
+        def _parse_statement(self) -> exp.Expression | None:
+            settings = None
+            if self._curr and self._curr.token_type == TokenType.SETTINGS:
+                index = self._index
+                start = self._curr
+                self._advance()
+                if self._curr and self._curr.token_type == TokenType.L_PAREN:
+                    self._parse_wrapped_csv(self._parse_assignment)
+                    settings = self._find_sql(start, self._prev)
+                else:
+                    self._retreat(index)
+
+            statement = super()._parse_statement()
+            if settings and statement:
+                statement.set("leading_settings", settings)
+            return statement
+
+    class Generator(ClickHouse.Generator):
+        def select_sql(self, expression: exp.Select) -> str:
+            sql = super().select_sql(expression)
+            settings = expression.args.get("leading_settings")
+            return f"{settings} {sql}" if settings else sql

--- a/superset/sql/dialects/databend.py
+++ b/superset/sql/dialects/databend.py
@@ -34,6 +34,19 @@ from sqlglot.tokens import TokenType
 
 class Databend(ClickHouse):
     class Parser(ClickHouse.Parser):
+        # ClickHouse reserves GLOBAL / SAMPLE / PREWHERE as keywords, but Databend
+        # accepts them as ordinary identifiers (verified against a live Databend:
+        # bare ``SELECT sample FROM t`` runs there, while bare ``union`` is
+        # rejected by Databend too, so it stays reserved). Restoring these keeps
+        # datasets whose columns are named after them parseable — they parsed
+        # under the generic dialect Databend previously fell back to.
+        ID_VAR_TOKENS = {
+            *ClickHouse.Parser.ID_VAR_TOKENS,
+            TokenType.GLOBAL,
+            TokenType.PREWHERE,
+            TokenType.TABLE_SAMPLE,
+        }
+
         def _parse_statement(self) -> exp.Expression | None:
             settings = None
             if self._curr and self._curr.token_type == TokenType.SETTINGS:

--- a/superset/sql/dialects/databend.py
+++ b/superset/sql/dialects/databend.py
@@ -52,7 +52,16 @@ class Databend(ClickHouse):
             return statement
 
     class Generator(ClickHouse.Generator):
-        def select_sql(self, expression: exp.Select) -> str:
-            sql = super().select_sql(expression)
-            settings = expression.args.get("leading_settings")
+        def generate(self, expression: exp.Expression, copy: bool = True) -> str:
+            # Re-emit the absorbed leading ``SETTINGS (...)`` at the statement
+            # root, so it survives regardless of the root's type — a bare
+            # SELECT, a UNION, a parenthesized subquery, or a non-query
+            # statement. ``select_sql`` alone would drop it on anything but a
+            # plain SELECT.
+            settings = (
+                expression.args.get("leading_settings")
+                if isinstance(expression, exp.Expression)
+                else None
+            )
+            sql = super().generate(expression, copy=copy)
             return f"{settings} {sql}" if settings else sql

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -45,7 +45,7 @@ from sqlglot.optimizer.scope import (
 )
 
 from superset.exceptions import QueryClauseValidationException, SupersetParseError
-from superset.sql.dialects import DB2, Dremio, Firebolt, Pinot
+from superset.sql.dialects import Databend, DB2, Dremio, Firebolt, Pinot
 
 if TYPE_CHECKING:
     from superset.models.core import Database
@@ -66,7 +66,7 @@ SQLGLOT_DIALECTS = {
     "cockroachdb": Dialects.POSTGRES,
     "couchbase": Dialects.MYSQL,
     # "crate": ???
-    # "databend": ???
+    "databend": Databend,
     "databricks": Dialects.DATABRICKS,
     "db2": DB2,
     # "denodo": ???

--- a/tests/unit_tests/sql/dialects/databend_tests.py
+++ b/tests/unit_tests/sql/dialects/databend_tests.py
@@ -47,6 +47,24 @@ def test_leading_settings_multiple_values() -> None:
     assert sqlglot.parse_one(sql, Databend).sql(dialect=Databend) == sql
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SETTINGS (a=1) SELECT 1 UNION ALL SELECT 2",
+        "SETTINGS (a=1) SELECT * FROM (SELECT id FROM u) AS sub",
+        "SETTINGS (a=1) WITH s AS (SELECT 1 AS one) SELECT * FROM s",
+    ],
+)
+def test_leading_settings_preserved_across_root_types(sql: str) -> None:
+    """
+    The wrapper must survive generation whatever the statement root is — not
+    only a bare SELECT. A UNION or a parenthesized subquery is re-emitted from
+    a generator hook other than ``select_sql``; emitting the settings only in
+    ``select_sql`` silently dropped the timeout guard on those.
+    """
+    assert sqlglot.parse_one(sql, Databend).sql(dialect=Databend) == sql
+
+
 def test_leading_settings_via_sqlscript_is_select() -> None:
     from superset.sql.parse import SQLScript
 
@@ -55,6 +73,32 @@ def test_leading_settings_via_sqlscript_is_select() -> None:
 
     assert len(script.statements) == 1
     assert not script.has_mutation()
+
+
+def test_leading_settings_survives_rls_regeneration() -> None:
+    """
+    User-visible path: when RLS is applied, virtual-dataset SQL is re-emitted
+    via ``SQLStatement.format`` (``superset/models/helpers.py``). The leading
+    ``SETTINGS`` must not be dropped there — for a UNION dataset too.
+    """
+    from superset.sql.parse import SQLStatement
+
+    sql = "SETTINGS (max_execute_time_in_seconds=300) SELECT 1 UNION ALL SELECT 2"
+    assert (
+        SQLStatement(sql, "databend")
+        .format()
+        .startswith("SETTINGS (max_execute_time_in_seconds=300)")
+    )
+
+
+def test_leading_settings_transparent_to_table_extraction() -> None:
+    """RLS depends on table extraction; the wrapper must not perturb it."""
+    from superset.sql.parse import SQLStatement
+
+    wrapped = SQLStatement("SETTINGS (a=1) SELECT c FROM myschema.t", "databend")
+    plain = SQLStatement("SELECT c FROM myschema.t", "databend")
+    extracted = {str(table) for table in wrapped.tables}
+    assert extracted == {str(table) for table in plain.tables} == {"myschema.t"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/sql/dialects/databend_tests.py
+++ b/tests/unit_tests/sql/dialects/databend_tests.py
@@ -65,6 +65,18 @@ def test_leading_settings_preserved_across_root_types(sql: str) -> None:
     assert sqlglot.parse_one(sql, Databend).sql(dialect=Databend) == sql
 
 
+def test_bare_leading_settings_keyword_is_not_special_cased() -> None:
+    """
+    Only the parenthesized ``SETTINGS (...)`` wrapper is absorbed. A bare leading
+    ``SETTINGS`` keyword with no parentheses is retreated and left to the base
+    parser, which rejects it — this exercises the non-wrapper retreat path.
+    """
+    import sqlglot.errors
+
+    with pytest.raises(sqlglot.errors.ParseError):
+        sqlglot.parse_one("SETTINGS SELECT 1", Databend)
+
+
 def test_leading_settings_via_sqlscript_is_select() -> None:
     from superset.sql.parse import SQLScript
 

--- a/tests/unit_tests/sql/dialects/databend_tests.py
+++ b/tests/unit_tests/sql/dialects/databend_tests.py
@@ -65,6 +65,33 @@ def test_leading_settings_preserved_across_root_types(sql: str) -> None:
     assert sqlglot.parse_one(sql, Databend).sql(dialect=Databend) == sql
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT sample FROM t",
+        "SELECT a FROM sample",
+        "SELECT global FROM t",
+        "SELECT prewhere FROM t",
+        "SELECT sample, global, prewhere FROM t",
+    ],
+)
+def test_clickhouse_reserved_words_stay_valid_identifiers(sql: str) -> None:
+    """
+    ClickHouse reserves GLOBAL / SAMPLE / PREWHERE, but Databend accepts them as
+    identifiers. Basing the dialect on ClickHouse must not make a dataset whose
+    column is named after one of them unparseable — that would be the very
+    "unqueryable virtual dataset" failure this dialect exists to prevent.
+    """
+    assert sqlglot.parse_one(sql, Databend) is not None
+
+
+def test_union_operator_still_parses() -> None:
+    """Restoring the reserved words above must not disturb the UNION operator."""
+    assert isinstance(
+        sqlglot.parse_one("SELECT 1 UNION ALL SELECT 2", Databend), exp.Union
+    )
+
+
 def test_bare_leading_settings_keyword_is_not_special_cased() -> None:
     """
     Only the parenthesized ``SETTINGS (...)`` wrapper is absorbed. A bare leading

--- a/tests/unit_tests/sql/dialects/databend_tests.py
+++ b/tests/unit_tests/sql/dialects/databend_tests.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import sqlglot
+from sqlglot import exp
+
+from superset.sql.dialects.databend import Databend
+
+
+def test_databend_dialect_registered() -> None:
+    from superset.sql.parse import SQLGLOT_DIALECTS
+
+    assert "databend" in SQLGLOT_DIALECTS
+    assert SQLGLOT_DIALECTS["databend"] is Databend
+
+
+def test_leading_settings_round_trips_unchanged() -> None:
+    """
+    A leading ``SETTINGS (...)`` timeout wrapper parses to a SELECT and is
+    re-emitted verbatim.
+    """
+    sql = 'SETTINGS (max_execute_time_in_seconds=300) SELECT "col" FROM t'
+    ast = sqlglot.parse_one(sql, Databend)
+
+    assert isinstance(ast, exp.Select)
+    assert ast.sql(dialect=Databend) == sql
+    assert [table.name for table in ast.find_all(exp.Table)] == ["t"]
+
+
+def test_leading_settings_multiple_values() -> None:
+    sql = "SETTINGS (a=1, b=2) SELECT 1"
+    assert sqlglot.parse_one(sql, Databend).sql(dialect=Databend) == sql
+
+
+def test_leading_settings_via_sqlscript_is_select() -> None:
+    from superset.sql.parse import SQLScript
+
+    sql = "SETTINGS (max_execute_time_in_seconds=300) SELECT col FROM t"
+    script = SQLScript(sql, "databend")
+
+    assert len(script.statements) == 1
+    assert not script.has_mutation()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1",
+        "SELECT a, b FROM t WHERE c > 1",
+        'SELECT COUNT(*) FROM "events" WHERE "type" = \'click\'',
+        "SELECT * FROM t SETTINGS max_threads = 1",
+        "SELECT `col` FROM `tbl`",
+        "SELECT * FROM a JOIN b ON a.id = b.id",
+        "SELECT DISTINCT x FROM t",
+        "SELECT x FROM t GROUP BY x HAVING COUNT(*) > 1",
+        "SELECT x FROM t ORDER BY x DESC LIMIT 10",
+        "WITH source AS (SELECT 1 AS one) SELECT * FROM source",
+        "SELECT * FROM (SELECT id FROM u) AS sub",
+        "SELECT CAST(a AS String) FROM t",
+        "INSERT INTO t VALUES (1)",
+        "ALTER TABLE foo ADD COLUMN bar INT",
+        "SELECT * FROM t WHERE name = 'O''Hara'",
+    ],
+)
+def test_no_regression_on_known_good_statements(sql: str) -> None:
+    """Statements that already parse under the generic dialect still parse."""
+    assert sqlglot.parse_one(sql, Databend) is not None

--- a/tests/unit_tests/sql/transpile_to_dialect_test.py
+++ b/tests/unit_tests/sql/transpile_to_dialect_test.py
@@ -253,6 +253,13 @@ def test_or_condition(sql: str, dialect: str, expected: str) -> None:
             "((a > 1 AND b < 2) OR (c = 3))",
         ),
         ("((a > 1 AND b < 2) OR (c = 3))", "mysql", "((a > 1 AND b < 2) OR (c = 3))"),
+        # databend routes through the ClickHouse-based dialect; an RLS predicate
+        # must transpile unchanged (guards the security-sensitive regen path).
+        (
+            "((a > 1 AND b < 2) OR (c = 3))",
+            "databend",
+            "((a > 1 AND b < 2) OR (c = 3))",
+        ),
     ],
 )
 def test_nested_conditions(sql: str, dialect: str, expected: str) -> None:

--- a/tests/unit_tests/sql/transpile_to_dialect_test.py
+++ b/tests/unit_tests/sql/transpile_to_dialect_test.py
@@ -272,10 +272,10 @@ def test_nested_conditions(sql: str, dialect: str, expected: str) -> None:
         "databricks",
         "presto",
         "trino",
+        "databend",
         # Unknown engines should return SQL unchanged
         "unknown_database_engine",
         "crate",
-        "databend",
         "db2",
         "denodo",
         "dynamodb",
@@ -296,7 +296,6 @@ def test_transpilation_does_not_error(dialect: str) -> None:
     [
         "unknown_database_engine",
         "crate",
-        "databend",
         "db2",
         "denodo",
         "dynamodb",


### PR DESCRIPTION
### Symptom
Every Databend tenant's SQL round-trips through sqlglot's **generic** dialect, at a point that fails **closed**. A leading `SETTINGS (max_execute_time_in_seconds=N) SELECT ...` — PlaidCloud's own query-timeout wrapper — raises `SupersetParseError`, which can make a virtual dataset unqueryable. Latent today (fleet scan: 0/182 virtual datasets currently carry the clause), but a real, deterministic trigger.

### Root cause
`superset/sql/parse.py` carried the placeholder `# "databend": ???`, so `SQLGLOT_DIALECTS.get("databend")` was `None`. Virtual datasets parse the rendered SQL twice in `superset/models/helpers.py` (`get_rendered_sql`, and again in `get_from_clause`). No built-in sqlglot dialect (generic, mysql, clickhouse, snowflake, duckdb, databricks) parses a **leading** `SETTINGS (...)`.

### Change
- New `superset/sql/dialects/databend.py`: `class Databend(ClickHouse)`. The parser absorbs a leading `SETTINGS (...)` (captured verbatim via `_find_sql`) into a `leading_settings` arg; the generator re-emits it. **Re-emission is done in `Generator.generate` (the statement root), not `select_sql`,** so the wrapper survives regardless of root type — a bare SELECT, a `UNION`/`EXCEPT`/`INTERSECT`, or a parenthesized subquery. Emitting only in `select_sql` silently dropped the timeout guard on non-SELECT roots (common for UNION virtual datasets). ClickHouse is a strict superset of generic for the known-good statements and also picks up trailing `SETTINGS` and backticks.
- Registered `"databend": Databend` in `parse.py`; exported from `dialects/__init__.py`.
- Moved `databend` out of the unknown-engine parametrize lists in `transpile_to_dialect_test.py` (it is now a known, registered engine) and added a `databend` case to `test_nested_conditions` locking the RLS-predicate transpile path.

### Verification (local — this fork's `unit-tests` CI rollup carries fork-wide debt, so evidence is the local run)
Branch merged up to current `develop-6.1` (picks up #355 optional `databend_sqlalchemy` import + #361 drop `--maxfail`), venv `uv venv --python 3.11`; sqlglot **28.10.0**.
- Runner sanity on unmodified tree: `pytest tests/unit_tests/sql/dialects/pinot_tests.py -q` → **267 passed**.
- Fails-before (no new test): `python -c "from superset.sql.parse import SQLGLOT_DIALECTS; assert 'databend' in SQLGLOT_DIALECTS"` → `AssertionError` before, passes after.
- `pytest tests/unit_tests/sql tests/unit_tests/db_engine_specs/test_databend.py` → **1048 passed, 4 skipped** (the 4 skips are the optional-`databend_sqlalchemy` engine-spec tests, skipped cleanly via #355 — no longer the 101 collection failures the pre-merge base had).
- New `databend_tests.py`: registration identity; leading-`SETTINGS` lossless round-trip; **preservation across UNION / subquery / CTE roots**; survival through the **RLS `SQLStatement.format()` regeneration path**; transparency to table extraction; `has_mutation` unchanged; 15-statement no-regression set. The UNION-preservation and RLS-regeneration cases **fail on the prior `select_sql`-only generator and pass with `generate()`** (verified by reverting the generator).
- Blast-radius (independent review): generic→ClickHouse switch changes only cosmetic spellings (`VARCHAR`→`String`, `INT`→`Int32`, extra parens) — all valid Databend, results unchanged; identifier quoting stays double-quote; `has_mutation`/table extraction **identical** generic-vs-databend across DML/DDL (read-only guards unweakened); `format(format(x))==format(x)` stable.

### CI note
`develop-6.1` is unprotected (no required checks). The red checks on this PR (`License Check`, `check-python-deps`, `python-dependency-liccheck`, `test-mysql`, `test-sqlite`, `test-postgres *`, `pre-commit *`) are fork-wide debt, red identically on sibling PRs and on `develop-6.1` itself — none are caused by this diff (none of the 5 changed files are flagged by any linter). The class that was stale-base-red (`unit-tests`, `test-load-examples`, `test-postgres-hive/presto`, cypress, playwright) goes green after the `develop-6.1` merge.

Story: https://app.shortcut.com/plaidcloud/story/23778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
