### PR TITLE
perf(migrations): index the FK columns on rls_filter_roles and rls_filter_tables (sc-23432)

### DIFF
--- a/superset/migrations/versions/2026-08-07_20-00_1622b23d91e2_add_fk_indexes_to_rls_filter_tables.py
+++ b/superset/migrations/versions/2026-08-07_20-00_1622b23d91e2_add_fk_indexes_to_rls_filter_tables.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add indexes on the FK columns of rls_filter_roles / rls_filter_tables
+
+Revision ID: 1622b23d91e2
+Revises: b7c1d94f0a52
+Create Date: 2026-08-07 20:00:00.000000
+
+sc-23432 (PlaidCloud row-level security) Part 5's rule + roster reconciler generates one
+Regular rule per (dataset, attribute, granted group) plus a conditional Base guard per
+(dataset, deny attribute) -- both `rls_filter_roles` and `rls_filter_tables` are read on
+every RLS-governed query (`SecurityManager.get_rls_filters`, which filters
+`RLSFilterRoles.c.role_id.in_(user_roles)` /
+`RLSFilterTables.c.table_id == table.id`), and both association tables carry only
+their own surrogate-key primary key today -- no index on either FK column. At the
+row counts a single project's worth of granted groups already produces (a
+200-dataset tenant with a few dozen groups reaches five figures of rows across the
+two tables), every one of those lookups is a full table scan.
+"""
+
+# revision identifiers, used by Alembic.
+revision = "1622b23d91e2"
+down_revision = "b7c1d94f0a52"
+
+
+from superset.migrations.shared.utils import create_index, drop_index  # noqa: E402
+
+
+def upgrade():
+    create_index(
+        "rls_filter_roles",
+        "ix_rls_filter_roles_role_id",
+        ["role_id"],
+        unique=False,
+    )
+    create_index(
+        "rls_filter_roles",
+        "ix_rls_filter_roles_rls_filter_id",
+        ["rls_filter_id"],
+        unique=False,
+    )
+    create_index(
+        "rls_filter_tables",
+        "ix_rls_filter_tables_table_id",
+        ["table_id"],
+        unique=False,
+    )
+    create_index(
+        "rls_filter_tables",
+        "ix_rls_filter_tables_rls_filter_id",
+        ["rls_filter_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    drop_index(
+        table_name="rls_filter_tables",
+        index_name="ix_rls_filter_tables_rls_filter_id",
+    )
+    drop_index(
+        table_name="rls_filter_tables",
+        index_name="ix_rls_filter_tables_table_id",
+    )
+    drop_index(
+        table_name="rls_filter_roles",
+        index_name="ix_rls_filter_roles_rls_filter_id",
+    )
+    drop_index(
+        table_name="rls_filter_roles",
+        index_name="ix_rls_filter_roles_role_id",
+    )


### PR DESCRIPTION
## Summary

`rls_filter_roles` and `rls_filter_tables` (the Regular/Base RLS association
tables) carry only their own surrogate-key primary key today — no index on
either FK column (`role_id` / `rls_filter_id` on the first, `table_id` /
`rls_filter_id` on the second). `SecurityManager.get_rls_filters` filters
`RLSFilterRoles.c.role_id.in_(user_roles)` and
`RLSFilterTables.c.table_id == table.id` on every RLS-governed query, so every
one of those lookups is a full table scan today.

This is task 24037 (sc-23432 Part 5, PlaidCloud's row-level security rule +
roster reconciler) — flagged as in-scope there, opened here because it's a
schema migration on this repository, with its own release train and review
surface. Follows the plain `create_index`/`drop_index` helper style already
used in `2024-01-05_16-20_65a167d4c62e_add_indexes_to_report_models.py`
rather than the raw-DDL/expression-index style of the immediately preceding
migration (`b7c1d94f0a52`) — these are ordinary single-column indexes, fully
reflected by the SQLite inspector used in the test suite, with no
cross-dialect expression syntax to work around.

## Test plan

- [x] `ruff check` clean on the new file.
- [x] `ruff format --diff` — no changes needed.
- [x] `black --check` — no changes needed.
- [x] Revision chain verified: `down_revision = "b7c1d94f0a52"` is the actual
      current head on `develop-6.1` (computed by walking every migration file
      for an unclaimed revision id — confirmed nothing else claims it).
- [ ] No local Superset environment was available to run `alembic upgrade
      head` end to end — relying on this repo's CI (`unit-tests`,
      `pre-commit`), confirmed green on `develop-6.1` as of tonight's
      `#355`, to exercise the migration for real. Flagged, not hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)