### PR TITLE
fix(ci): drop pytest --maxfail=50, add develop-6.1/beta-6.1 push triggers

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - "master"
       - "[0-9].[0-9]*"
+      - "develop-6.1"
+      - "beta-6.1"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
@@ -44,7 +46,7 @@ jobs:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
-          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50
+          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear
       - name: Python 100% coverage unit tests
         if: steps.check.outputs.python
         env:


### PR DESCRIPTION
## Residual scope only

PR #355 already fixed the CI root cause (made the `databend_sqlalchemy` import
optional in `superset/db_engine_specs/databend.py` with a dummy fallback
class) — that PR merged 2026-08-07 and CI is now green on the full suite
(`5615 passed, 11 skipped`, `--cov-fail-under=100` reached, all three matrix
legs). This PR is just the two leftover gate-hygiene edits from the original
story; it does **not** touch `requirements/`, `databend.py`, or any lockfile.

## Changes

`.github/workflows/superset-python-unittest.yml`:

1. **Remove `--maxfail=50`** from the unit-test pytest invocation.
   `--maxfail` is reasonable on a healthy suite and actively harmful on a
   broken one — it converts "many failures" into "most of the suite silently
   unrun," which is the exact failure this story documented (a run aborting
   at ~1,391 of 5,630 collected). With the suite green, removing it costs a
   few minutes of runner time on a badly-broken PR and buys an always-visible
   true failure count.

2. **Add `develop-6.1` and `beta-6.1` to the push trigger**, keeping the
   existing `master` and `[0-9].[0-9]*` entries (removing them is out of
   scope and would diverge further from upstream, even though `master` is
   dead in this fork). The last 30 Python-Unit runs are 100% `pull_request` —
   there has never been a post-merge run on this fork's live integration
   line, so a merge that breaks `develop-6.1` or `beta-6.1` is invisible
   until the next PR opens.

The `beta-6.1` cherry-pick of this change remains a human step and is out of
scope here.

## Verification

- `git diff origin/develop-6.1` — exactly one file changed, only the two
  edits above.
- `git status --porcelain` — clean, no other files touched.
- YAML parse check:
  ```
  python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/superset-python-unittest.yml')); print(d[True]['push']['branches'])"
  # -> ['master', '[0-9].[0-9]*', 'develop-6.1', 'beta-6.1']
  ```
  (`d['on']` raises `KeyError` because PyYAML parses the bare `on:` key as
  boolean `True`; used `d[True]` instead.)
- No Python test suite run — this change alters no Python code, only a CI
  workflow's trigger list and a pytest CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)