### PR TITLE
fix(reports): enforce RLS and query access on alert SQL (sc-24052)

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -39,11 +39,13 @@ from superset.commands.report.exceptions import (
     AlertValidatorConfigError,
 )
 from superset.reports.models import ReportSchedule, ReportScheduleValidatorType
+from superset.sql.parse import SQLScript
 from superset.tasks.utils import get_executor
 from superset.utils import json
 from superset.utils.core import override_user
 from superset.utils.decorators import logs_context
 from superset.utils.retries import retry_call
+from superset.utils.rls import apply_rls
 
 logger = logging.getLogger(__name__)
 
@@ -189,30 +191,50 @@ class AlertCommand(BaseCommand):
         :raises AlertQueryError: SQL query is not valid
         :raises AlertQueryTimeout: The SQL query received a celery soft timeout
         """
-        sql_template = jinja_context.get_template_processor(
-            database=self._report_schedule.database
-        )
+        database = self._report_schedule.database
+        sql_template = jinja_context.get_template_processor(database=database)
         rendered_sql = sql_template.process_template(self._report_schedule.sql)
         try:
-            limited_rendered_sql = self._report_schedule.database.apply_limit_to_sql(
-                rendered_sql, ALERT_SQL_LIMIT
-            )
-
-            if app.config["MUTATE_ALERT_QUERY"]:
-                limited_rendered_sql = (
-                    self._report_schedule.database.mutate_sql_based_on_config(
-                        limited_rendered_sql
-                    )
-                )
-
             executor, username = get_executor(  # pylint: disable=unused-variable
                 executors=app.config["ALERT_REPORTS_EXECUTORS"],
                 model=self._report_schedule,
             )
             user = security_manager.find_user(username)
             with override_user(user):
+                catalog = database.get_default_catalog()
+                schema = database.get_default_schema(catalog)
+
+                # Alert authoring only checks database visibility, so enforce here
+                # that the executor may query every table the SQL touches.
+                security_manager.raise_for_access(
+                    database=database,
+                    sql=rendered_sql,
+                    catalog=catalog,
+                    schema=schema,
+                )
+
+                # Inject RLS predicates the way SQL Lab does. Re-serialise only
+                # when a predicate actually applied, so un-governed SQL passes
+                # through byte-identical. A parse failure fails closed via the
+                # generic handler below rather than executing unfiltered.
+                script = SQLScript(rendered_sql, database.db_engine_spec.engine)
+                rls_applied = False
+                for statement in script.statements:
+                    if apply_rls(database, catalog, schema or "", statement):
+                        rls_applied = True
+                if rls_applied:
+                    rendered_sql = script.format()
+
+                limited_rendered_sql = database.apply_limit_to_sql(
+                    rendered_sql, ALERT_SQL_LIMIT
+                )
+                if app.config["MUTATE_ALERT_QUERY"]:
+                    limited_rendered_sql = database.mutate_sql_based_on_config(
+                        limited_rendered_sql
+                    )
+
                 start = default_timer()
-                df = self._report_schedule.database.get_df(sql=limited_rendered_sql)
+                df = database.get_df(sql=limited_rendered_sql)
                 stop = default_timer()
                 logger.info(
                     "Query for %s took %.2f ms",

--- a/superset/commands/report/base.py
+++ b/superset/commands/report/base.py
@@ -22,6 +22,7 @@ from flask import current_app as app
 from flask_babel import gettext as _
 from marshmallow import ValidationError
 
+from superset import security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.report.exceptions import (
     ChartNotFoundValidationError,
@@ -29,11 +30,14 @@ from superset.commands.report.exceptions import (
     DashboardNotFoundValidationError,
     DashboardNotSavedValidationError,
     ReportScheduleEitherChartOrDashboardError,
+    ReportScheduleForbiddenError,
     ReportScheduleFrequencyNotAllowed,
     ReportScheduleOnlyChartOrDashboardError,
 )
 from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
+from superset.exceptions import SupersetSecurityException
+from superset.models.core import Database
 from superset.reports.models import ReportCreationMethod, ReportScheduleType
 from superset.reports.types import ReportScheduleExtra
 from superset.utils import json
@@ -82,6 +86,27 @@ class BaseReportScheduleCommand(BaseCommand):
             self._properties["dashboard"] = dashboard
         elif not update:
             exceptions.append(ReportScheduleEitherChartOrDashboardError())
+
+    def raise_for_alert_database_access(
+        self, database: Database, sql: Optional[str]
+    ) -> None:
+        """
+        Ensure the current user may query every table the alert SQL touches.
+
+        Alert authoring only checks that the database is *visible* (any of
+        database/catalog/schema/datasource access), so without this a single
+        dataset grant would authorize arbitrary SQL against the whole database.
+        """
+        catalog = database.get_default_catalog()
+        try:
+            security_manager.raise_for_access(
+                database=database,
+                sql=sql,
+                catalog=catalog,
+                schema=database.get_default_schema(catalog),
+            )
+        except SupersetSecurityException as ex:
+            raise ReportScheduleForbiddenError() from ex
 
     def _validate_report_extra(self, exceptions: list[ValidationError]) -> None:
         extra: Optional[ReportScheduleExtra] = self._properties.get("extra")

--- a/superset/commands/report/create.py
+++ b/superset/commands/report/create.py
@@ -122,6 +122,9 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
                 database_id = self._properties["database"]
                 if database := DatabaseDAO.find_by_id(database_id):
                     self._properties["database"] = database
+                    self.raise_for_alert_database_access(
+                        database, self._properties.get("sql")
+                    )
                 else:
                     exceptions.append(DatabaseNotFoundValidationError())
             except KeyError:

--- a/superset/commands/report/update.py
+++ b/superset/commands/report/update.py
@@ -120,6 +120,14 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
                 exceptions.append(DatabaseNotFoundValidationError())
             self._properties["database"] = database
 
+        # Enforce query access to the alert's target database (create-time parity):
+        # visibility alone must not authorize arbitrary SQL against the whole database.
+        if report_type == ReportScheduleType.ALERT and has_database and not exceptions:
+            self.raise_for_alert_database_access(
+                self._properties.get("database") or self._model.database,
+                self._properties.get("sql") or self._model.sql,
+            )
+
         # validate report frequency
         try:
             self.validate_report_frequency(

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from unittest.mock import Mock
 from uuid import uuid4
 
 import numpy as np
@@ -510,7 +511,7 @@ def _alert_command_with_db(
     mocker: MockerFixture,
     *,
     rendered_sql: str = "SELECT value FROM metrics",
-) -> tuple[AlertCommand, object]:
+) -> tuple[AlertCommand, Mock]:
     """Wire a real ``AlertCommand._execute_query`` with a mocked database."""
     database = mocker.Mock()
     database.db_engine_spec.engine = "postgresql"
@@ -587,15 +588,15 @@ def test_execute_query_passthrough_when_no_rls(mocker: MockerFixture) -> None:
     """Un-governed SQL is passed through byte-identical (no reformat)."""
     rendered = "SELECT value FROM metrics"
     command, database = _alert_command_with_db(mocker, rendered_sql=rendered)
-    mocker.patch.object(security_manager, "raise_for_access")
+    raise_for_access = mocker.patch.object(security_manager, "raise_for_access")
     mocker.patch("superset.commands.report.alert.apply_rls", return_value=False)
 
     command._execute_query()
 
     assert database.get_df.call_args.kwargs["sql"] == rendered
-    security_manager.raise_for_access.assert_called_once()
-    assert security_manager.raise_for_access.call_args.kwargs["sql"] == rendered
-    assert security_manager.raise_for_access.call_args.kwargs["database"] is database
+    raise_for_access.assert_called_once()
+    assert raise_for_access.call_args.kwargs["sql"] == rendered
+    assert raise_for_access.call_args.kwargs["database"] is database
 
 
 def test_execute_query_applies_rls_to_every_statement(

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -22,9 +22,16 @@ import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
 
+from superset import security_manager
 from superset.commands.report.alert import AlertCommand
-from superset.commands.report.exceptions import AlertValidatorConfigError
+from superset.commands.report.exceptions import (
+    AlertQueryError,
+    AlertValidatorConfigError,
+)
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetSecurityException
 from superset.reports.models import ReportScheduleValidatorType, ReportState
+from superset.sql.parse import SQLScript
 
 
 def test_empty_query_result_with_operator_validator_returns_false_with_message(
@@ -494,3 +501,115 @@ def test_not_null_validator_with_empty_result_does_not_trigger(
 
     assert triggered is False, "NOT_NULL with empty result should not trigger"
     assert command._result is None
+
+
+# --- _execute_query: access check + RLS on the raw alert SQL channel (sc-24052) ---
+
+
+def _alert_command_with_db(
+    mocker: MockerFixture,
+    *,
+    rendered_sql: str = "SELECT value FROM metrics",
+) -> tuple[AlertCommand, object]:
+    """Wire a real ``AlertCommand._execute_query`` with a mocked database."""
+    database = mocker.Mock()
+    database.db_engine_spec.engine = "postgresql"
+    database.get_default_catalog.return_value = None
+    database.get_default_schema.return_value = "public"
+    database.apply_limit_to_sql.side_effect = lambda sql, limit: sql
+    database.get_df.return_value = pd.DataFrame({"value": [1]})
+
+    report_schedule = mocker.Mock()
+    report_schedule.database = database
+    report_schedule.sql = rendered_sql
+    report_schedule.id = 1
+
+    template = mocker.Mock()
+    template.process_template.side_effect = lambda sql: sql
+    mocker.patch(
+        "superset.commands.report.alert.jinja_context.get_template_processor",
+        return_value=template,
+    )
+    mocker.patch(
+        "superset.commands.report.alert.get_executor",
+        return_value=("owner", "alert_user"),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.security_manager.find_user",
+        return_value=mocker.Mock(),
+    )
+    mocker.patch("superset.commands.report.alert.override_user")
+
+    command = AlertCommand(report_schedule=report_schedule, execution_id=uuid4())
+    return command, database
+
+
+def test_execute_query_denied_access_raises_and_skips_query(
+    mocker: MockerFixture,
+) -> None:
+    """A user who cannot query the target tables never reaches the warehouse."""
+    command, database = _alert_command_with_db(mocker)
+    mocker.patch.object(
+        security_manager,
+        "raise_for_access",
+        side_effect=SupersetSecurityException(
+            SupersetError(
+                message="denied",
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+    mocker.patch("superset.commands.report.alert.apply_rls", return_value=False)
+
+    with pytest.raises(AlertQueryError):
+        command._execute_query()
+    database.get_df.assert_not_called()
+
+
+def test_execute_query_reserializes_sql_when_rls_applied(
+    mocker: MockerFixture,
+) -> None:
+    """When a predicate applies, the re-serialized SQL is what executes."""
+    rendered = "SELECT value FROM metrics"
+    command, database = _alert_command_with_db(mocker, rendered_sql=rendered)
+    mocker.patch.object(security_manager, "raise_for_access")
+    mocker.patch("superset.commands.report.alert.apply_rls", return_value=True)
+
+    command._execute_query()
+
+    executed_sql = database.get_df.call_args.kwargs["sql"]
+    assert executed_sql == SQLScript(rendered, "postgresql").format()
+    assert executed_sql != rendered
+
+
+def test_execute_query_passthrough_when_no_rls(mocker: MockerFixture) -> None:
+    """Un-governed SQL is passed through byte-identical (no reformat)."""
+    rendered = "SELECT value FROM metrics"
+    command, database = _alert_command_with_db(mocker, rendered_sql=rendered)
+    mocker.patch.object(security_manager, "raise_for_access")
+    mocker.patch("superset.commands.report.alert.apply_rls", return_value=False)
+
+    command._execute_query()
+
+    assert database.get_df.call_args.kwargs["sql"] == rendered
+    security_manager.raise_for_access.assert_called_once()
+    assert security_manager.raise_for_access.call_args.kwargs["sql"] == rendered
+    assert security_manager.raise_for_access.call_args.kwargs["database"] is database
+
+
+def test_execute_query_applies_rls_to_every_statement(
+    mocker: MockerFixture,
+) -> None:
+    """RLS is applied to all statements — no short-circuit on the first hit."""
+    command, _ = _alert_command_with_db(
+        mocker, rendered_sql="SELECT a FROM t1; SELECT b FROM t2"
+    )
+    mocker.patch.object(security_manager, "raise_for_access")
+    apply_rls_mock = mocker.patch(
+        "superset.commands.report.alert.apply_rls", return_value=True
+    )
+
+    command._execute_query()
+
+    assert apply_rls_mock.call_count == 2

--- a/tests/unit_tests/commands/report/create_test.py
+++ b/tests/unit_tests/commands/report/create_test.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for CreateReportScheduleCommand.validate() alert access control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset import security_manager
+from superset.commands.report.create import CreateReportScheduleCommand
+from superset.commands.report.exceptions import ReportScheduleForbiddenError
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetSecurityException
+from superset.reports.models import ReportCreationMethod, ReportScheduleType
+
+
+def _alert_props(**overrides: Any) -> dict[str, Any]:
+    props: dict[str, Any] = {
+        "type": ReportScheduleType.ALERT,
+        "name": "alert1",
+        "crontab": "0 9 * * *",
+        "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+        "database": 5,
+        "sql": "SELECT value FROM metrics",
+        "owners": [],
+    }
+    props.update(overrides)
+    return props
+
+
+def _setup(mocker: MockerFixture, *, database: Any) -> None:
+    mocker.patch(
+        "superset.commands.report.create.ReportScheduleDAO.validate_update_uniqueness",
+        return_value=True,
+    )
+    mocker.patch(
+        "superset.commands.report.create.ReportScheduleDAO.validate_unique_creation_method",
+        return_value=True,
+    )
+    mocker.patch(
+        "superset.commands.report.create.DatabaseDAO.find_by_id",
+        return_value=database,
+    )
+    mocker.patch.object(CreateReportScheduleCommand, "validate_report_frequency")
+    mocker.patch.object(CreateReportScheduleCommand, "validate_chart_dashboard")
+    mocker.patch.object(CreateReportScheduleCommand, "populate_owners", return_value=[])
+
+
+def test_alert_create_checks_query_access(mocker: MockerFixture) -> None:
+    database = mocker.Mock()
+    _setup(mocker, database=database)
+    raise_for_access = mocker.patch.object(security_manager, "raise_for_access")
+
+    CreateReportScheduleCommand(_alert_props()).validate()
+
+    raise_for_access.assert_called_once()
+    assert raise_for_access.call_args.kwargs["database"] is database
+    assert raise_for_access.call_args.kwargs["sql"] == "SELECT value FROM metrics"
+
+
+def test_alert_create_denied_access_raises_forbidden(mocker: MockerFixture) -> None:
+    database = mocker.Mock()
+    _setup(mocker, database=database)
+    mocker.patch.object(
+        security_manager,
+        "raise_for_access",
+        side_effect=SupersetSecurityException(
+            SupersetError(
+                message="denied",
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+
+    with pytest.raises(ReportScheduleForbiddenError):
+        CreateReportScheduleCommand(_alert_props()).validate()

--- a/tests/unit_tests/commands/report/update_test.py
+++ b/tests/unit_tests/commands/report/update_test.py
@@ -23,10 +23,14 @@ from unittest.mock import Mock
 import pytest
 from pytest_mock import MockerFixture
 
+from superset import security_manager
 from superset.commands.report.exceptions import (
+    ReportScheduleForbiddenError,
     ReportScheduleInvalidError,
 )
 from superset.commands.report.update import UpdateReportScheduleCommand
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetSecurityException
 from superset.reports.models import ReportScheduleType
 
 
@@ -57,6 +61,9 @@ def _setup_mocks(mocker: MockerFixture, model: Mock) -> None:
     )
     mocker.patch(
         "superset.commands.report.update.security_manager.raise_for_ownership",
+    )
+    mocker.patch(
+        "superset.commands.report.update.security_manager.raise_for_access",
     )
     mocker.patch(
         "superset.commands.report.update.DatabaseDAO.find_by_id",
@@ -252,3 +259,44 @@ def test_report_to_alert_with_db_accepted(mocker: MockerFixture) -> None:
         data={"type": ReportScheduleType.ALERT, "database": 5},
     )
     cmd.validate()  # should not raise
+
+
+# --- Alert query-access enforcement (sc-24052) ---
+
+
+def test_alert_update_checks_query_access(mocker: MockerFixture) -> None:
+    """An alert update enforces query access against the effective database."""
+    model = _make_model(mocker, model_type=ReportScheduleType.ALERT, database_id=5)
+    model.database = mocker.Mock()
+    _setup_mocks(mocker, model)
+    database = mocker.Mock()
+    mocker.patch(
+        "superset.commands.report.update.DatabaseDAO.find_by_id",
+        return_value=database,
+    )
+    raise_for_access = mocker.patch.object(security_manager, "raise_for_access")
+
+    UpdateReportScheduleCommand(model_id=1, data={"database": 5}).validate()
+
+    raise_for_access.assert_called_once()
+    assert raise_for_access.call_args.kwargs["database"] is database
+
+
+def test_alert_update_denied_access_raises_forbidden(mocker: MockerFixture) -> None:
+    model = _make_model(mocker, model_type=ReportScheduleType.ALERT, database_id=5)
+    model.database = mocker.Mock()
+    _setup_mocks(mocker, model)
+    mocker.patch.object(
+        security_manager,
+        "raise_for_access",
+        side_effect=SupersetSecurityException(
+            SupersetError(
+                message="denied",
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+
+    with pytest.raises(ReportScheduleForbiddenError):
+        UpdateReportScheduleCommand(model_id=1, data={"database": 5}).validate()


### PR DESCRIPTION
## Symptom
Alert conditions execute attacker-authored SQL straight against the warehouse with **no RLS** and **no per-table access check**, while alert authoring is gated only on database *visibility*. Since `DatabaseFilter` (`superset/databases/filters.py:58-76`) admits a database on **any** of `database_access`/`catalog_access`/`schema_access`/`datasource_access`, a user with Alpha-level report write and access to a single dataset can run arbitrary SQL against that entire database — RLS-free, without ever holding SQL Lab. The scalar result is then readable back via the report REST API (`last_value` / `last_value_row_json`).

Not exploitable in production today: `ALERT_REPORTS` is off fleet-wide and there are zero `ReportSchedule` rows. This closes the latent hole before the flag is ever enabled.

## Root cause
`superset/commands/report/alert.py` `_execute_query` rendered the alert SQL and handed it to `Database.get_df` — the only place `report_schedule.sql` executes — bypassing the three `apply_rls` call sites and any data-access check. Create/update (`create.py:119-128`, `update.py:117-121`) validated only that the database was *found*, never that the author could query it.

## What changed
- **`alert.py::_execute_query`** — the whole body now runs inside `override_user`, and before execution:
  1. `security_manager.raise_for_access(database, sql, catalog, schema)` — the same per-table check SQL Lab uses.
  2. RLS predicates injected per statement via `utils.rls.apply_rls` (mirroring `sql/execution/executor.py:730-744`), re-serialising **only** when a predicate actually applied, so un-governed SQL is passed through byte-identical. A parse failure fails **closed** (`AlertQueryError`), never executing unfiltered. Not gated on `RLS_IN_SQLLAB` — alerts are not SQL Lab.
- **`create.py` / `update.py`** — require the authoring user to hold query access to the alert's target database, via a shared `raise_for_alert_database_access` helper on `BaseReportScheduleCommand`. This closes the "one dataset grant opens the whole database" escalation and is effective immediately (checked as the authoring user, independent of the runtime executor identity).

## Verification
This fork's `unit-tests` CI rollup is unreliable, so the real evidence is the local run:

```
uv venv --python 3.11 .venv
uv pip install --python .venv/bin/python -r requirements/development.txt
SUPERSET_TESTENV=true SUPERSET_SECRET_KEY=not-a-secret PYTHONPATH=$PWD \
  .venv/bin/python -m pytest tests/unit_tests/commands/report/ -q --no-cov -p no:cacheprovider
```

- Before (unmodified `develop-6.1`): **154 passed**
- After: **162 passed** (+8 new — 4 exercising the real `_execute_query` for access-deny / RLS-reserialise / passthrough / all-statements, 2 create, 2 update; each fails on unmodified source). The 3 existing `update_test.py` alert cases were repaired to permit the new access check.
- Full `tests/unit_tests/commands/`: **457 passed**.
- `ruff check` + `ruff format --check` clean; `pylint` 10.00/10; `mypy --check-untyped-defs --follow-imports=silent` clean on the four source files (only a pre-existing `croniter` stub note, supplied by pre-commit in CI).

Story: https://app.shortcut.com/plaidcloud/story/24052

🤖 Generated with [Claude Code](https://claude.com/claude-code)