### PR TITLE
fix(security): promote RLS write guard fix to beta-6.1 (sc-23432)

### DIFF
--- a/plaid/rls_guard.py
+++ b/plaid/rls_guard.py
@@ -121,13 +121,28 @@ Superset differently:
 * RLS rules: ``RLSRestApi`` (``superset/row_level_security/api.py``) has no
   equivalent override attribute -- Superset registers the class directly. Its
   ``post`` / ``put`` / ``delete`` / ``bulk_delete`` are monkeypatched in place
-  by ``install()`` below, called from ``PlaidSecurityManager.__init__`` --
-  which Superset's app factory runs during app construction, well before the
-  app accepts its first request, and after ``super().__init__`` has already
-  pulled in Superset's own security wiring. Patching the class attribute is
-  sufficient: Python resolves ``self.post(...)`` from the class's current
+  by ``install()`` below. Importing ``RLSRestApi`` transitively reaches
+  ``superset.db_engine_specs.base``, whose module-scope Marshmallow schemas
+  call Flask-Babel's ``gettext`` at import time -- which raises
+  ``KeyError: 'babel'`` if run before FAB's own ``AppBuilder.init_app``
+  registers Babel on the app (``flask_appbuilder/base.py``: the security
+  manager is constructed at line 201, Babel at line 202). Calling
+  ``install()`` eagerly from ``PlaidSecurityManager.__init__`` -- which runs
+  at that line-201 construction step -- therefore crashed every process that
+  builds the app, web, celery worker, and celerybeat alike (sc-23432). It is
+  instead registered as a Flask ``before_request`` hook
+  (``current_app.before_request(rls_guard.install)``, in
+  ``plaid/security.py``): FAB registers its own
+  ``before_request(self.sm.before_request)`` at ``base.py:207``, strictly
+  after Babel exists, and no request is dispatched until long after
+  ``create_app()`` returns, so by the time any request reaches a route,
+  Babel is present and ``install()`` -- idempotent, see below -- has already
+  patched the class before that request's view function runs. Patching the
+  class attribute (rather than the instance) is what makes this safe to
+  defer at all: Python resolves ``self.post(...)`` from the class's current
   ``__dict__`` at CALL time, not at route-registration time, so ordering
-  relative to ``add_api(RLSRestApi)`` does not matter.
+  relative to ``add_api(RLSRestApi)`` -- which still happens earlier, in
+  ``init_views()`` -- does not matter either.
 """
 
 from __future__ import annotations

--- a/plaid/security.py
+++ b/plaid/security.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 
 import jwt
 from authlib.integrations.flask_client import token_update
-from flask import session
+from flask import current_app, session
 from flask_appbuilder import Model
 from flask_appbuilder.security.manager import AUTH_OAUTH
 from flask_login import logout_user
@@ -86,21 +86,51 @@ class PlaidSecurityManager(SupersetSecurityManager):
         # app.config['AUTH_ROLES_SYNC_AT_LOGIN'] = True
         super().__init__(appbuilder)
 
-        # sc-23432 Part 4 -- the RLS rules API (`RowLevelSecurityFilter`) has
-        # no override attribute like `role_api` above; `RLSRestApi`'s write
-        # routes are patched in place instead. Here, not at module import
-        # time: `RLSRestApi` pulls in Superset's command/DAO layer, which
-        # this constructor -- running after `super().__init__`, well after
-        # Superset's own app factory has set up its view registry, and still
-        # well before the app accepts its first request -- is a safer point
-        # to depend on than being importable at `plaid.security`'s own
-        # module-load time. See `plaid/rls_guard.py`.
-        rls_guard.install()
-
-        # The actual control for role/group escalation -- see rls_guard's
-        # module docstring "What this protects" section for why route
-        # patching alone (RoleApi above) is not enough on its own.
+        # sc-23432 Part 4 -- install_orm_listeners() only imports FAB's own
+        # `flask_appbuilder.security.sqla.models` (Group, Role) -- it never
+        # touches Superset's command/DAO/db_engine_specs layer, so it is safe
+        # to run right here, unconditionally, in every process that
+        # constructs a security manager (web, celery worker, celerybeat,
+        # CLI). This is the actual control for role/group escalation -- see
+        # rls_guard's module docstring "What this protects" section for why
+        # route patching alone (RoleApi above, and `install()` below) is not
+        # enough on its own.
         rls_guard.install_orm_listeners()
+
+        # rls_guard.install() patches `RLSRestApi` in place, which pulls in
+        # `superset.row_level_security.api` -> ... -> `superset.models.core`
+        # -> `superset.db_engine_specs.base`. That last module's Marshmallow
+        # schemas call Flask-Babel's `gettext` (`__(...)`) at class-body
+        # (i.e. import) time. FAB's own `AppBuilder.init_app` constructs the
+        # security manager -- this `__init__` -- at `base.py:201`, and only
+        # registers Babel on the app two lines later, at `base.py:202`
+        # (`self.bm = BabelManager(self)`, which calls `Babel(current_app,
+        # ...)`). Calling `rls_guard.install()` here, eagerly, imports
+        # `db_engine_specs.base` before Babel exists in `app.extensions`,
+        # raising `KeyError: 'babel'` and taking down every worker at boot
+        # (sc-23432) -- including celerybeat and celery workers, which build
+        # the same app but never serve HTTP requests.
+        #
+        # Defer to a `before_request` hook instead of importing here. FAB
+        # registers its own `app.before_request(self.sm.before_request)` at
+        # `base.py:207` -- strictly after `BabelManager` is constructed --
+        # and no HTTP request is ever dispatched until well after
+        # `create_app()` has returned. So by the time ANY request reaches
+        # this app, Babel is guaranteed present, and `before_request` hooks
+        # always run before the matched view function on EVERY request, not
+        # just the first. `rls_guard.install()` is idempotent (an
+        # `_plaid_rls_guard_installed` flag short-circuits every call after
+        # the first), so registering it here costs one cheap attribute check
+        # per request and closes the window completely: even the very first
+        # request that tries to write a protected RLS rule via
+        # `RLSRestApi.post/put/delete/bulk_delete` cannot reach that method
+        # before this hook has already patched it, because `before_request`
+        # callbacks always complete before Flask dispatches to the view.
+        # Processes that never serve a request (celerybeat, a one-off CLI
+        # command) simply never install the route patch -- correctly, since
+        # there is no route to guard there; `install_orm_listeners()` above
+        # is what protects those processes' own ORM writes.
+        current_app.before_request(rls_guard.install)
 
         if self.auth_type == AUTH_OAUTH:
             self.authoauthview = PlaidAuthOAuthView

--- a/tests/unit_tests/plaid/test_app_boot.py
+++ b/tests/unit_tests/plaid/test_app_boot.py
@@ -1,0 +1,191 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sc-23432 -- regression test for the app-boot crash that took Superset's
+celerybeat and worker pods down on every beta tenant.
+
+`PlaidSecurityManager.__init__` used to call `rls_guard.install()` eagerly.
+`install()` imports `superset.row_level_security.api.RLSRestApi`, which
+transitively reaches `superset.db_engine_specs.base` -- whose module-scope
+Marshmallow schemas call Flask-Babel's `gettext` (`__(...)`) at import time.
+FAB's own `AppBuilder.init_app` constructs the security manager at
+`flask_appbuilder/base.py:201` and only registers Babel on the app two lines
+later, at `:202` (`self.bm = BabelManager(self)`). Importing `RLSRestApi`
+from inside that `__init__` therefore ran before Babel existed in
+`app.extensions`, raising `KeyError: 'babel'` and crashing every process
+that constructs the app -- web workers, celery workers, and celerybeat
+alike, none of which need an HTTP request to build it.
+
+`test_rls_guard.py`'s 42 tests all passed while this was broken: that file
+deliberately imports only `plaid.rls_guard` (never `plaid.security`, never a
+real app-factory boot) specifically to dodge the `plaidcloud.rpc` dependency
+gate -- see its own module docstring. A test that only imports `rls_guard`
+reproduces that exact blind spot. This file instead builds the app the same
+way the container does: `superset.app:create_app()`, with
+`CUSTOM_SECURITY_MANAGER` wired to `PlaidSecurityManager`, the way every
+tenant's deployed `superset_config.py` wires it.
+
+Runs in a subprocess rather than in-process. `superset.row_level_security.api`
+(and everything it pulls in, including `db_engine_specs.base`) is *also*
+imported unconditionally by Superset's own `init_views()` on every app boot,
+crash or no crash. Once that import has succeeded anywhere in this pytest
+process -- e.g. from another test module's `app` fixture building a plain
+app earlier in the same session -- Python caches the module, and the
+Babel-at-import-time crash this guards against can never reproduce again in
+that process, regardless of test order. Only a fresh interpreter, with a
+virgin `sys.modules`, exercises the actual import order FAB and
+`plaid.security` produce at real boot.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# plaid/ imports plaidcloud-rpc, which is in requirements/base.txt but not in
+# the development.txt that CI installs, so this module is only importable
+# where the runtime dependencies are present (the superset image). Skipping
+# loudly beats a collection error that aborts the whole unit-test run -- see
+# test_security.py.
+pytest.importorskip("plaidcloud.rpc.connection.jsonrpc")
+
+
+def test_app_boots_with_plaid_security_manager_wired(tmp_path):
+    """The regression check: a fresh process constructing the app via the
+    real factory entrypoint, with `PlaidSecurityManager` wired in exactly
+    the way a deployed tenant wires it, must not raise.
+
+    Before the fix, this fails with `KeyError: 'babel'` out of
+    `plaid/security.py`'s `PlaidSecurityManager.__init__` ->
+    `rls_guard.install()` -> `superset.row_level_security.api` ->
+    `superset.db_engine_specs.base`. After the fix, `install()` is deferred
+    to a `before_request` hook (see `plaid/security.py`), so construction
+    alone never imports that chain.
+    """
+    home = tmp_path / "superset_home"
+    home.mkdir()
+    config_path = tmp_path / "superset_config.py"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            from plaid.security import PlaidSecurityManager
+
+            CUSTOM_SECURITY_MANAGER = PlaidSecurityManager
+            """
+        )
+    )
+
+    env = {
+        **os.environ,
+        "SUPERSET_HOME": str(home),
+        "SUPERSET_CONFIG_PATH": str(config_path),
+        "SUPERSET_TESTENV": "true",
+        "SUPERSET_SECRET_KEY": "not-a-secret",
+    }
+
+    result = subprocess.run(  # noqa: S603 -- fixed argv, no shell, no untrusted input
+        [sys.executable, "-c", "from superset.app import create_app; create_app()"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        "App construction crashed in a fresh process -- this is the exact "
+        "boot path every worker, celery worker, and celerybeat process runs "
+        f"(sc-23432). Captured stderr:\n{result.stderr[-4000:]}"
+    )
+    assert "KeyError: 'babel'" not in result.stderr
+
+
+def test_route_guard_installed_before_first_request_dispatches(tmp_path):
+    """The window that actually matters, per sc-23432's non-negotiable: the
+    guard must be installed before any request can mutate a role or RLS
+    rule. Also run in a subprocess for the same cache-freshness reason as
+    above, and because it needs the same `CUSTOM_SECURITY_MANAGER` wiring.
+
+    Asserts the guard is (a) NOT installed from construction alone -- proving
+    the fix actually defers it, not just happens to avoid the crash some
+    other way -- and (b) IS installed after one request is dispatched through
+    Flask's real WSGI test client, before that request's own view function
+    would have had a chance to run.
+    """
+    home = tmp_path / "superset_home"
+    home.mkdir()
+    config_path = tmp_path / "superset_config.py"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            from plaid.security import PlaidSecurityManager
+
+            CUSTOM_SECURITY_MANAGER = PlaidSecurityManager
+            """
+        )
+    )
+
+    env = {
+        **os.environ,
+        "SUPERSET_HOME": str(home),
+        "SUPERSET_CONFIG_PATH": str(config_path),
+        "SUPERSET_TESTENV": "true",
+        "SUPERSET_SECRET_KEY": "not-a-secret",
+    }
+
+    script = textwrap.dedent(
+        """
+        from superset.app import create_app
+
+        # Import RLSRestApi only after create_app() -- importing it beforehand
+        # pulls in superset.models.core at config-load time, which raises its
+        # own unrelated "App not initialized yet" out of encrypted_field_factory
+        # (see plaid/security.py's ADMIN_ONLY_VIEW_MENUS comment for the same
+        # gotcha). create_app()'s own init_views() already imports RLSRestApi
+        # unconditionally, so it is guaranteed importable by this point.
+        app = create_app()
+        from superset.row_level_security.api import RLSRestApi
+
+        assert getattr(RLSRestApi, "_plaid_rls_guard_installed", False) is False, (
+            "guard should not be installed from construction alone"
+        )
+
+        client = app.test_client()
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+        assert getattr(RLSRestApi, "_plaid_rls_guard_installed", False) is True, (
+            "guard must be installed before the first request's view function runs"
+        )
+        print("OK")
+        """
+    )
+
+    result = subprocess.run(  # noqa: S603 -- fixed argv, no shell, no untrusted input
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout[-2000:]}\nstderr:\n{result.stderr[-4000:]}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
Re-promotion of the RLS write guard (originally #360) after the previous promotion crashed Superset's celerybeat and worker pods on all five beta tenants (10h outage, incl. `pw-pwc` and `pw-tartan`). Rolled back to `beta-6.1-133-1` (`9800ae39`).

**Root cause:** `PlaidSecurityManager.__init__` called `rls_guard.install()` eagerly, which imports `superset.row_level_security.api` -> ... -> `superset.db_engine_specs.base`, whose module-scope Marshmallow schemas call Flask-Babel's `gettext` at import time. FAB's `AppBuilder.init_app` constructs the security manager two lines before it registers Babel on the app, so this raised `KeyError: 'babel'` and crashed every process that builds the app — web, celery worker, and celerybeat alike.

**Fix (#364):** `install()` is now registered as a Flask `before_request` hook instead of called directly, so it runs after Babel is registered. `install_orm_listeners()` has no Babel dependency and stays eager.

Commit carried: `414a59139` — fix(security): defer rls_guard.install() past FAB's Babel registration (sc-23432) (#364)

**Canary verification on `bugfixes2` (tracks develop-6.1 directly) before opening this PR:**
- New image: `develop-6.1-376-1`
- `plaid-superset` 3/3 available, `plaid-superset-celerybeat` 1/1 available, `plaid-superset-worker` 3/3 available — all on `develop-6.1-376-1`, zero restarts
- Log line confirmed on all three workload types: `plaid_rls ORM-level role/group guard installed.`
- (Prior to rollout, pods were still crashlooping on the pre-fix `develop-6.1-375-1` tag with the exact same `KeyError: 'babel'` trace — confirming this PR's fix is what resolves it.)

Merge with `--merge` (real merge commit, not squash) to preserve ancestry for future RC promotions.