### PR TITLE
ci: install helm-docs from pinned release instead of Homebrew tap

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,7 +40,17 @@ jobs:
           echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >>"${GITHUB_ENV}"
           echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR" >>"${GITHUB_ENV}"
           echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY" >>"${GITHUB_ENV}"
-          brew install norwoodj/tap/helm-docs
+          # Install helm-docs from the pinned GitHub release rather than the
+          # Homebrew tap: `brew install norwoodj/tap/helm-docs` fails on the
+          # runner now that Homebrew refuses untrusted third-party taps
+          # non-interactively ("tap is not trusted" -> broken pipe). Keep the
+          # version in sync with the helm-docs hook in .pre-commit-config.yaml.
+          HELM_DOCS_VERSION=1.14.2
+          curl -fsSL -o /tmp/helm-docs.tar.gz \
+            "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+          tar -xzf /tmp/helm-docs.tar.gz -C /tmp helm-docs
+          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
+          helm-docs --version
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
### SUMMARY

The `pre-commit` CI job's **"Enable brew and helm-docs"** step runs
`brew install norwoodj/tap/helm-docs`, which now fails on the GitHub
runner: Homebrew refuses the untrusted third-party tap non-interactively
(`Skipping norwoodj/tap because it is not trusted` → `Broken pipe`), so
the step exits `1` **before any hook runs**. This turns the entire
pre-commit check red on every PR, regardless of the diff.

This PR installs `helm-docs` directly from its GitHub release instead of
the Homebrew tap, pinned to **v1.14.2** to match the `helm-docs` hook in
`.pre-commit-config.yaml`. The download is deterministic and independent
of Homebrew's tap-trust behavior. Brew is still added to `PATH` for any
other use.

```diff
-          brew install norwoodj/tap/helm-docs
+          HELM_DOCS_VERSION=1.14.2
+          curl -fsSL -o /tmp/helm-docs.tar.gz \
+            "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+          tar -xzf /tmp/helm-docs.tar.gz -C /tmp helm-docs
+          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
+          helm-docs --version
```

### TESTING INSTRUCTIONS

- The `pre-commit` job should now complete the setup step and run the
  hooks (previously it died at `brew install`). Confirm the
  `Enable brew and helm-docs` step prints `helm-docs version v1.14.2`.
- Locally verified: the release asset exists, the URL returns `200`, the
  tarball contains `helm-docs` at its root, and it extracts/installs
  cleanly on `Linux_x86_64`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Keep `HELM_DOCS_VERSION` in sync with the `rev:` of the `helm-docs` hook
in `.pre-commit-config.yaml` on future bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
